### PR TITLE
cleaned up test setup procedure

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
     "^.+\\.(ts|tsx)$": "ts-jest",
   },
   setupFiles: ["dotenv/config"],
+  setupFilesAfterEnv: ['<rootDir>/src/testsetup/setupTests.ts']
 };

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -11,5 +11,6 @@ export const database = new Sequelize(
     dialectOptions: {
       ssl: { require: process.env.DB_SSL == "true", rejectUnauthorized: false },
     },
+    logging: process.env.SQL_LOGGING == "true"
   }
 );

--- a/backend/src/models/tests/artist.test.ts
+++ b/backend/src/models/tests/artist.test.ts
@@ -30,6 +30,3 @@ test("get artist", async () => {
 
 //TODO can we think of more tests to make sure our database works as expected?
 
-afterAll(async () => {
-  await database.close();
-});

--- a/backend/src/models/tests/borough.test.ts
+++ b/backend/src/models/tests/borough.test.ts
@@ -30,6 +30,3 @@ test("get borough", async () => {
 
 //TODO can we think of more tests to make sure our database works as expected?
 
-afterAll(async () => {
-  await database.close();
-});

--- a/backend/src/models/tests/mural.test.ts
+++ b/backend/src/models/tests/mural.test.ts
@@ -19,25 +19,6 @@ const params = {
   },
 };
 
-beforeAll(async () => {
-  await Mural.belongsTo(Borough, {
-    foreignKey: { allowNull: false, name: "boroughId" },
-  });
-  await Mural.belongsTo(Artist, {
-    foreignKey: { allowNull: false, name: "artistId" },
-  });
-  await Mural.belongsToMany(Tour, {
-    foreignKey: "muralId",
-    through: "murals_in_tour",
-    as: "tours",
-  });
-  await Tour.belongsToMany(Mural, {
-    foreignKey: "tourId",
-    through: "murals_in_tour",
-    as: "murals",
-  });
-});
-
 beforeEach(async () => {
   await database.sync({ force: true });
   //we can assume the following lines work, they are tested in another test suite
@@ -154,6 +135,3 @@ test("test updating coordinates", async () => {
   expect(mural2!.coordinates.coordinates).toEqual([-69.123123, 69.232454]);
 });
 
-afterAll(async () => {
-  await database.close();
-});

--- a/backend/src/models/tests/muralcollection.test.ts
+++ b/backend/src/models/tests/muralcollection.test.ts
@@ -4,25 +4,6 @@ import { Borough } from "../borough.model";
 import { Artist } from "../artist.model";
 import { MuralCollection } from "../muralcollection.model";
 
-beforeAll(async () => {
-  await Mural.belongsTo(Borough, {
-    foreignKey: { allowNull: false, name: "boroughId" },
-  });
-  await Mural.belongsTo(Artist, {
-    foreignKey: { allowNull: false, name: "artistId" },
-  });
-  await Mural.belongsToMany(MuralCollection, {
-    foreignKey: "muralId",
-    through: "murals_in_collection",
-    as: "collections",
-  });
-  await MuralCollection.belongsToMany(Mural, {
-    foreignKey: "collectionId",
-    through: "murals_in_collection",
-    as: "murals",
-  });
-});
-
 beforeEach(async () => {
   await database.sync({ force: true });
   //we can assume the following lines work, they are tested in another test suite
@@ -202,6 +183,3 @@ test("remove associated mural", async () => {
   expect(muralCnt).toEqual(0);
 });
 
-afterAll(async () => {
-  await database.close();
-});

--- a/backend/src/models/tests/tour.test.ts
+++ b/backend/src/models/tests/tour.test.ts
@@ -4,25 +4,6 @@ import { Borough } from "../borough.model";
 import { Artist } from "../artist.model";
 import { Tour } from "../tour.model";
 
-beforeAll(async () => {
-  await Mural.belongsTo(Borough, {
-    foreignKey: { allowNull: false, name: "boroughId" },
-  });
-  await Mural.belongsTo(Artist, {
-    foreignKey: { allowNull: false, name: "artistId" },
-  });
-  await Mural.belongsToMany(Tour, {
-    foreignKey: "muralId",
-    through: "murals_in_tour",
-    as: "tours",
-  });
-  await Tour.belongsToMany(Mural, {
-    foreignKey: "tourId",
-    through: "murals_in_tour",
-    as: "murals",
-  });
-});
-
 beforeEach(async () => {
   await database.sync({ force: true });
   //we can assume the following lines work, they are tested in another test suite
@@ -202,6 +183,3 @@ test("remove associated mural", async () => {
   expect(muralCnt).toEqual(0);
 });
 
-afterAll(async () => {
-  await database.close();
-});

--- a/backend/src/services/tests/artist.test.ts
+++ b/backend/src/services/tests/artist.test.ts
@@ -85,7 +85,3 @@ test("update invalid artist", async () => {
     .then(() => fail())
     .catch((err: Error) => expect(true).toEqual(true));
 });
-
-afterAll(async () => {
-  await database.close();
-});

--- a/backend/src/services/tests/borough.test.ts
+++ b/backend/src/services/tests/borough.test.ts
@@ -1,4 +1,3 @@
-import { database } from "../../config/database";
 import { Borough } from "../../models/borough.model";
 import { BoroughService } from "../borough.service";
 
@@ -80,8 +79,4 @@ test("update invalid borough", async () => {
     .update(1, params)
     .then(() => fail())
     .catch((err: Error) => expect(true).toEqual(true));
-});
-
-afterAll(async () => {
-  await database.close();
 });

--- a/backend/src/services/tests/muralcollection.test.ts
+++ b/backend/src/services/tests/muralcollection.test.ts
@@ -2,32 +2,11 @@ import { database } from "../../config/database";
 import { MuralCollection } from "../../models/muralcollection.model";
 import { MuralCollectionService } from "../muralcollection.service";
 import { Mural } from "../../models/mural.model";
-import { Borough } from "../../models/borough.model";
-import { Artist } from "../../models/artist.model";
 
 const params = {
   name: "testCollection",
   description: "des",
 };
-
-beforeAll(async () => {
-  Mural.belongsTo(Borough, {
-    foreignKey: { allowNull: false, name: "boroughId" },
-  });
-  Mural.belongsTo(Artist, {
-    foreignKey: { allowNull: false, name: "artistId" },
-  });
-  Mural.belongsToMany(MuralCollection, {
-    foreignKey: "muralId",
-    through: "murals_in_collection",
-    as: "collections",
-  });
-  MuralCollection.belongsToMany(Mural, {
-    foreignKey: "collectionId",
-    through: "murals_in_collection",
-    as: "murals",
-  });
-});
 
 beforeEach(async () => {
   await MuralCollection.sync({ force: true });
@@ -140,6 +119,3 @@ test("update invalid mural collection", async () => {
     .catch((err: Error) => expect(true).toEqual(true));
 });
 
-afterAll(async () => {
-  await database.close();
-});

--- a/backend/src/services/tests/tour.test.ts
+++ b/backend/src/services/tests/tour.test.ts
@@ -46,7 +46,3 @@ test("show invalid tour", async () => {
     .then(() => fail())
     .catch((err: Error) => expect(true).toEqual(true));
 });
-
-afterAll(async () => {
-  await database.close();
-});

--- a/backend/src/testsetup/setupTests.ts
+++ b/backend/src/testsetup/setupTests.ts
@@ -1,0 +1,40 @@
+import { database } from "../config/database";
+import { MuralCollection } from "../models/muralcollection.model";
+import { Tour } from "../models/tour.model";
+import { Mural } from "../models/mural.model";
+import { Borough } from "../models/borough.model";
+import { Artist } from "../models/artist.model";
+
+beforeAll(async () => {
+  await database.query("CREATE EXTENSION IF NOT EXISTS postgis");
+  Mural.belongsTo(Borough, {
+    foreignKey: { allowNull: false, name: "boroughId" },
+  });
+  Mural.belongsTo(Artist, {
+    foreignKey: { allowNull: false, name: "artistId" },
+  });
+  Mural.belongsToMany(MuralCollection, {
+    foreignKey: "muralId",
+    through: "murals_in_collection",
+    as: "collections",
+  });
+  MuralCollection.belongsToMany(Mural, {
+    foreignKey: "collectionId",
+    through: "murals_in_collection",
+    as: "murals",
+  });
+  Mural.belongsToMany(Tour, {
+    foreignKey: "muralId",
+    through: "murals_in_tour",
+    as: "tours",
+  });
+  Tour.belongsToMany(Mural, {
+    foreignKey: "tourId",
+    through: "murals_in_tour",
+    as: "murals",
+  });
+});
+
+afterAll(async () => {
+  await database.close();
+});


### PR DESCRIPTION
# Summary
Cleaned up setup for tests by creating associations in only one file rather than in each,
also added an env variable to determine SQL logging (put SQL_LOGGING=false in your .env file if you don't want to see all the spam console output during tests)

## Test Plan
Ran the tests

## Related Issues
none