### PR TITLE
Feature/37 get all murals

### DIFF
--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -15,6 +15,7 @@ export class Routes {
   public routes(app: Application): void {
     app
       .route("/mural")
+      .get(this.muralController.showAll.bind(this.muralController))
       .post(this.muralController.create.bind(this.muralController));
 
     app

--- a/backend/src/controllers/mural.controller.ts
+++ b/backend/src/controllers/mural.controller.ts
@@ -6,6 +6,16 @@ import { MuralService } from "../services/mural.service";
 export class MuralController {
   public muralService: MuralService = new MuralService();
 
+  // GET all /mural
+  public async showAll(req: Request, res: Response) {
+    try {
+      const murals = await this.muralService.showAll();
+      res.status(202).json(murals);
+    } catch (e) {
+      res.status(500).json({ error: "Something went wrong." });
+    }
+  }
+
   // POST /mural
   public async create(req: Request, res: Response) {
     const params: MuralInterface = req.body;

--- a/backend/src/controllers/mural.controller.ts
+++ b/backend/src/controllers/mural.controller.ts
@@ -8,8 +8,10 @@ export class MuralController {
 
   // GET all /mural
   public async showAll(req: Request, res: Response) {
+    const limit = Number(req.query.limit ?? 40);
+    const offset = Number(req.query.page ?? 0) * limit;
     try {
-      const murals = await this.muralService.showAll();
+      const murals = await this.muralService.showAll(limit, offset);
       res.status(202).json(murals);
     } catch (e) {
       res.status(500).json({ error: "Something went wrong." });

--- a/backend/src/models/mural.model.ts
+++ b/backend/src/models/mural.model.ts
@@ -3,7 +3,6 @@ import {
   DataTypes,
   BelongsToManyCountAssociationsMixin,
   BelongsToManyAddAssociationMixin,
-  BelongsToManyCreateAssociationMixin,
   BelongsToManyGetAssociationsMixin,
   BelongsToManyHasAssociationMixin,
 } from "sequelize";

--- a/backend/src/services/mural.service.ts
+++ b/backend/src/services/mural.service.ts
@@ -16,6 +16,11 @@ export class MuralService {
     return { success: true, body: createdMural };
   }
 
+  public async showAll() {
+    const murals = await Mural.findAndCountAll<Mural>({ where: {} });
+    return { success: true, murals: murals };
+  }
+
   public async show(muralId: number) {
     const mural = await Mural.findByPk<Mural>(muralId, { rejectOnEmpty: true });
     return { success: true, mural: mural };

--- a/backend/src/services/mural.service.ts
+++ b/backend/src/services/mural.service.ts
@@ -16,8 +16,11 @@ export class MuralService {
     return { success: true, body: createdMural };
   }
 
-  public async showAll() {
-    const murals = await Mural.findAndCountAll<Mural>({ where: {} });
+  public async showAll(limit: number, offset: number) {
+    const murals = await Mural.findAndCountAll<Mural>({
+      limit: limit,
+      offset: offset
+    });
     return { success: true, murals: murals };
   }
 


### PR DESCRIPTION
# Summary

- Add endpoint to get all murals
- Murals can be paginated: to get only the first 5, pass `limit: 5` as a param from Postman or Axios. Then, to get the next 5, pass `limit: 5` and `page: 1` as params.

## Test Plan

Tried it in Postman:

<img width="392" alt="Screen Shot 2020-12-27 at 6 58 18 PM" src="https://user-images.githubusercontent.com/36117635/103187684-4f22b880-4893-11eb-8ca0-5ac857ebbb32.png">

## Related Issues

Closes #37 