### PR TITLE
Add socialMediaURLs to Mural model

### DIFF
--- a/backend/src/models/mural.model.ts
+++ b/backend/src/models/mural.model.ts
@@ -20,7 +20,8 @@ export class Mural extends Model {
   public partners!: string[];
   public assistants!: string[];
   public coordinates!: any;
-  public imgUrl!: string[];
+  public imgURLs!: string[];
+  public socialMediaURLs!: string[];
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
 
@@ -84,8 +85,12 @@ Mural.init(
       type: DataTypes.GEOMETRY("POINT", 4326),
       allowNull: false,
     },
-    imgUrl: {
-      type: DataTypes.TEXT,
+    imgURLs: {
+      type: DataTypes.ARRAY(DataTypes.TEXT),
+      allowNull: true,
+    },
+    socialMediaURLs: {
+      type: DataTypes.ARRAY(DataTypes.TEXT),
       allowNull: true,
     },
   },
@@ -109,5 +114,6 @@ export interface MuralInterface {
   assistants?: string[];
   longitude: number;
   latitude: number;
-  imgUrl?: string;
+  imgURLs?: string[];
+  socialMediaURLs?: string[];
 }


### PR DESCRIPTION
# Summary

Added socialMediaURLs field to mural model as a string array. 

Fixed inconsistency in imgURLs (?)
I noticed imgURLs was typed as an array in the export but as a single string in the init and interface. I changed the typing to be a string array everywhere as the prototype in #66 shows that the gallery can contain multiple images.

## Test Plan

No additional tests were added. All tests still pass.

## Related Issues

#70 #66
