### PR TITLE
Feature/85 collection form

### DIFF
--- a/frontend/src/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/ActionButtons/ActionButtons.tsx
@@ -1,0 +1,67 @@
+import {
+  Button,
+  createStyles,
+  makeStyles,
+  Theme,
+} from "@material-ui/core";
+import React from "react";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    bottomButton: {
+      margin: theme.spacing(0, 0, 0, 3)
+    },
+    bottomButtonContainer: {
+      display: "flex",
+      justifyContent: "flex-end",
+      padding: theme.spacing(3),
+      width: "40vw",
+      maxWidth: "500px",
+      position: "fixed",
+      bottom: 0
+    },
+  })
+);
+
+interface IActionButtonsProps {
+  saveCallback: () => void;
+  cancelCallback: () => void;
+}
+
+function ActionButtons({ saveCallback, cancelCallback }: IActionButtonsProps) {
+
+  const styles = useStyles();
+
+  const handleSave = () => {
+    saveCallback()
+  };
+
+  const handleCancel = () => {
+    cancelCallback()
+  };
+
+  return (
+    <div className={styles.bottomButtonContainer}>
+      <Button
+        color="secondary"
+        size="small"
+        variant="outlined"
+        className={styles.bottomButton}
+        onClick={handleCancel}
+      >
+        Cancel
+      </Button>
+      <Button
+        color="primary"
+        size="small"
+        variant="contained"
+        disableElevation
+        className={styles.bottomButton}
+        onClick={handleSave}>
+        Save
+      </Button>
+    </div>
+  )
+}
+
+export default ActionButtons

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -6,6 +6,7 @@ import Sidebar from "../sidebar/Sidebar";
 import PlusButton from "../plusButton/PlusButton";
 import Search from "../Search/Search";
 import MuralForm from "../muralForm/MuralForm";
+import CollectionForm from "../CollectionForm/CollectionForm";
 import SigninForm from "../SignInForm/SigninForm";
 import Context from "../context";
 import "firebase/auth";
@@ -65,7 +66,7 @@ function App() {
   };
 
   const getMural = async () => {
-    const response = await fetch("http://localhost:3000/mural");
+    const response = await fetch("http://mumapbackend.us-east-1.elasticbeanstalk.com/mural");
     const data = await response.json();
 
     setMurals(data.murals.rows);
@@ -99,7 +100,8 @@ function App() {
         >
           {
             !searchResult.length ?
-              (<MuralForm />) :
+              // (<MuralForm />) :
+              (<CollectionForm />) :
               (<SearchCard searchCards={searchResult} />)
           }
         </Sidebar>

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -66,7 +66,7 @@ function App() {
   };
 
   const getMural = async () => {
-    const response = await fetch("http://mumapbackend.us-east-1.elasticbeanstalk.com/mural");
+    const response = await fetch("http://localhost:3000/mural");
     const data = await response.json();
 
     setMurals(data.murals.rows);

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -100,10 +100,10 @@ function App() {
         >
           {
             !searchResult.length ?
-              // (<MuralForm />) :
               (<CollectionForm />) :
               (<SearchCard searchCards={searchResult} />)
           }
+          {false && (<MuralForm />)}
         </Sidebar>
         <PlusButton isVisible={true} handleClick={toggleSidebar} />
       </Context.Provider>

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -1,14 +1,16 @@
 import {
+    Button,
     createStyles,
     InputAdornment,
     InputBase,
     makeStyles,
+    TextField,
     Theme
 } from "@material-ui/core";
 import axios from "axios";
-import React, { useEffect, useState } from "react";
+import React, { SyntheticEvent, useEffect, useState } from "react";
 import EditIcon from '@material-ui/icons/Edit';
-import SearchBar from "Search/Search";
+import Autocomplete from "@material-ui/lab/Autocomplete";
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -17,11 +19,11 @@ const useStyles = makeStyles((theme: Theme) =>
             flexDirection: "column",
             alignItems: "start",
             width: "40vw",
-            padding: theme.spacing(2)
+            padding: theme.spacing(3)
         },
         field: {
             width: "100%",
-            margin: theme.spacing(1, 1, 3, 1)
+            margin: theme.spacing(2, 0, 2, 0)
         },
         title: {
             fontSize: "180%",
@@ -31,13 +33,18 @@ const useStyles = makeStyles((theme: Theme) =>
         },
         bottomButtonContainer: {
             display: "flex",
+            bottom: 0,
             justifyContent: "space-between",
+            padding: theme.spacing(3)
         },
     })
 );
 
 function CollectionForm() {
-    const [murals, setMurals] = useState([]);
+    const [murals, setMurals] = useState<any>([]);
+    const [muralsInCollection, setMuralsInCollection] = useState<any>([]);
+    const [muralResults, setMuralResults] = useState<any>([]);
+    const [muralQuery, setMuralQuery] = useState<string>("");
 
     const [description, setDescription] = useState([]);
     const [editingDesc, setEditingDesc] = useState<boolean>(false);
@@ -49,6 +56,24 @@ function CollectionForm() {
 
     const styles = useStyles();
 
+    const handleAddMural = (addedMural: any) => {
+        if (!addedMural) return
+        if (muralsInCollection.some((currMural: any) => currMural.id === addedMural.id))
+            return
+
+        setMuralsInCollection((oldMurals: any) => [...oldMurals, addedMural]);
+    };
+
+    const handleSave = () => {
+        console.log(title)
+        console.log(description)
+        console.log(muralsInCollection)
+    };
+
+    const handleCancel = () => {
+        console.log("cancel")
+    };
+
     useEffect(() => {
         // TODO: remember to replace this with localhost before merging
         axios.get('http://mumapbackend.us-east-1.elasticbeanstalk.com/mural')
@@ -58,47 +83,92 @@ function CollectionForm() {
             .catch(err => console.log(err));
     }, []);
 
+    useEffect(() => {
+        const filtered = murals.filter((mural: any) => {
+            return mural.name.toLowerCase().includes(muralQuery)
+        });
+        setMuralResults(filtered);
+    }, [muralQuery, murals]);
+
     return (
-        <form noValidate autoComplete="off">
+        <div>
             <div className={styles.flexContainer}>
-                <InputBase
-                    className={`${styles.title} ${styles.field}`}
-                    defaultValue="Name the collection"
-                    onChange={(e: any) => setTitle(e.target.value)}
-                    inputProps={{ 'aria-label': 'New collection title' }}
-                    onClick={() => setEditingTitle(true)}
-                    onBlur={() => setEditingTitle(false)}
-                    onMouseEnter={() => setHoveringTitle(true)}
-                    onMouseLeave={() => setHoveringTitle(false)}
-                    endAdornment={!editingTitle && (
-                        <InputAdornment position="start">
-                            <EditIcon color={hoveringTitle ? "primary" : "action"} />
-                        </InputAdornment>
-                    )}
-                />
-                <InputBase
-                    className={styles.field}
-                    multiline
-                    rows={4}
-                    placeholder="Add a description"
-                    onChange={(e: any) => setDescription(e.target.value)}
-                    onClick={() => setEditingDesc(true)}
-                    onBlur={() => setEditingDesc(false)}
-                    onMouseEnter={() => setHoveringDesc(true)}
-                    onMouseLeave={() => setHoveringDesc(false)}
-                    endAdornment={!editingDesc && (
-                        <InputAdornment position="start">
-                            <EditIcon color={hoveringDesc ? "primary" : "action"} />
-                        </InputAdornment>
-                    )}
-                />
-                <div className={styles.field}>
-                    <SearchBar
-                        searchCallBack={(e: any) => console.log(e)}
+                <form
+                    noValidate
+                    autoComplete="off"
+                    onSubmit={(e: SyntheticEvent) => { e.preventDefault(); handleSave() }}>
+                    <InputBase
+                        className={`${styles.title} ${styles.field}`}
+                        defaultValue="Name the collection"
+                        onChange={(e: any) => setTitle(e.target.value)}
+                        inputProps={{ 'aria-label': 'New collection title' }}
+                        onClick={() => setEditingTitle(true)}
+                        onBlur={() => setEditingTitle(false)}
+                        onMouseEnter={() => setHoveringTitle(true)}
+                        onMouseLeave={() => setHoveringTitle(false)}
+                        endAdornment={!editingTitle && (
+                            <InputAdornment position="start">
+                                <EditIcon color={hoveringTitle ? "primary" : "action"} />
+                            </InputAdornment>
+                        )}
                     />
-                </div>
+                    <InputBase
+                        className={styles.field}
+                        multiline
+                        rows={4}
+                        placeholder="Add a description"
+                        onChange={(e: any) => setDescription(e.target.value)}
+                        onClick={() => setEditingDesc(true)}
+                        onBlur={() => setEditingDesc(false)}
+                        onMouseEnter={() => setHoveringDesc(true)}
+                        onMouseLeave={() => setHoveringDesc(false)}
+                        endAdornment={!editingDesc && (
+                            <InputAdornment position="start">
+                                <EditIcon color={hoveringDesc ? "primary" : "action"} />
+                            </InputAdornment>
+                        )}
+                    />
+                    <div className={styles.field}>
+                        <Autocomplete
+                            freeSolo
+                            options={muralResults.map((mural: any) => mural)}
+                            getOptionLabel={(mural: any) => mural.name}
+                            onChange={(e: any, value: any) => handleAddMural(value)}
+                            renderInput={(params) => (
+                                <TextField
+                                    {...params}
+                                    label="Add a mural"
+                                    variant="outlined"
+                                    size="small"
+                                    onChange={
+                                        (e: any) => setMuralQuery(e.target.value.toLowerCase())
+                                    }
+                                />
+                            )}
+                        />
+                    </div>
+                </form>
             </div>
-        </form>
+            <div className={styles.bottomButtonContainer}>
+                <Button
+                    color="secondary"
+                    size="small"
+                    variant="outlined"
+                    className={styles.bottomButton}
+                    onClick={handleCancel}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    color="primary"
+                    size="small"
+                    variant="contained"
+                    disableElevation
+                    onClick={handleSave}>
+                    Save
+                </Button>
+            </div>
+        </div>
     )
 }
 

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -19,6 +19,7 @@ const useStyles = makeStyles((theme: Theme) =>
             flexDirection: "column",
             alignItems: "start",
             width: "40vw",
+            maxWidth: "500px",
             padding: theme.spacing(3)
         },
         field: {
@@ -29,13 +30,16 @@ const useStyles = makeStyles((theme: Theme) =>
             fontSize: "180%",
         },
         bottomButton: {
-            fontWeight: 500,
+            margin: theme.spacing(0, 0, 0, 3)
         },
         bottomButtonContainer: {
             display: "flex",
-            bottom: 0,
-            justifyContent: "space-between",
-            padding: theme.spacing(3)
+            justifyContent: "flex-end",
+            padding: theme.spacing(3),
+            width: "40vw",
+            maxWidth: "500px",
+            position: "fixed",
+            bottom: 0
         },
     })
 );
@@ -92,11 +96,11 @@ function CollectionForm() {
 
     return (
         <div>
-            <div className={styles.flexContainer}>
-                <form
-                    noValidate
-                    autoComplete="off"
-                    onSubmit={(e: SyntheticEvent) => { e.preventDefault(); handleSave() }}>
+            <form
+                noValidate
+                autoComplete="off"
+                onSubmit={(e: SyntheticEvent) => { e.preventDefault(); handleSave() }}>
+                <div className={styles.flexContainer}>
                     <InputBase
                         className={`${styles.title} ${styles.field}`}
                         defaultValue="Name the collection"
@@ -147,8 +151,8 @@ function CollectionForm() {
                             )}
                         />
                     </div>
-                </form>
-            </div>
+                </div>
+            </form>
             <div className={styles.bottomButtonContainer}>
                 <Button
                     color="secondary"
@@ -164,6 +168,7 @@ function CollectionForm() {
                     size="small"
                     variant="contained"
                     disableElevation
+                    className={styles.bottomButton}
                     onClick={handleSave}>
                     Save
                 </Button>

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -41,11 +41,11 @@ function CollectionForm() {
   const [muralResults, setMuralResults] = useState<any>([]);
   const [muralQuery, setMuralQuery] = useState<string>("");
 
-  const [description, setDescription] = useState([]);
+  const [description, setDescription] = useState<string>("");
   const [editingDesc, setEditingDesc] = useState<boolean>(false);
   const [hoveringDesc, setHoveringDesc] = useState<boolean>(false);
 
-  const [title, setTitle] = useState([]);
+  const [title, setTitle] = useState<string>("");
   const [editingTitle, setEditingTitle] = useState<boolean>(false);
   const [hoveringTitle, setHoveringTitle] = useState<boolean>(false);
 
@@ -137,7 +137,7 @@ function CollectionForm() {
           />
           <div className={styles.field}>
             <Autocomplete
-              freeSolo
+              freeSolo={false}
               options={muralResults.map((mural: any) => mural)}
               getOptionLabel={(mural: any) => mural.name}
               onChange={(e: any, value: any) => handleAddMural(value)}

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -64,8 +64,7 @@ function CollectionForm() {
   const handleSave = () => {
     if (!title.length || !description.length) return;
 
-    // TODO: remember to replace this with localhost before merging
-    axios.post('http://mumapbackend.us-east-1.elasticbeanstalk.com/collection', {
+    axios.post('http://localhost:3000/collection', {
       collection: {
         name: title,
         description: description
@@ -84,8 +83,7 @@ function CollectionForm() {
   };
 
   useEffect(() => {
-    // TODO: remember to replace this with localhost before merging
-    axios.get('http://mumapbackend.us-east-1.elasticbeanstalk.com/mural')
+    axios.get('http://localhost:3000/mural')
       .then((response) => {
         if (response.data) setMurals(response.data.murals.rows)
       })

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -1,0 +1,105 @@
+import {
+    createStyles,
+    InputAdornment,
+    InputBase,
+    makeStyles,
+    Theme
+} from "@material-ui/core";
+import axios from "axios";
+import React, { useEffect, useState } from "react";
+import EditIcon from '@material-ui/icons/Edit';
+import SearchBar from "Search/Search";
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        flexContainer: {
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "start",
+            width: "40vw",
+            padding: theme.spacing(2)
+        },
+        field: {
+            width: "100%",
+            margin: theme.spacing(1, 1, 3, 1)
+        },
+        title: {
+            fontSize: "180%",
+        },
+        bottomButton: {
+            fontWeight: 500,
+        },
+        bottomButtonContainer: {
+            display: "flex",
+            justifyContent: "space-between",
+        },
+    })
+);
+
+function CollectionForm() {
+    const [murals, setMurals] = useState([]);
+
+    const [description, setDescription] = useState([]);
+    const [editingDesc, setEditingDesc] = useState<boolean>(false);
+    const [hoveringDesc, setHoveringDesc] = useState<boolean>(false);
+
+    const [title, setTitle] = useState([]);
+    const [editingTitle, setEditingTitle] = useState<boolean>(false);
+    const [hoveringTitle, setHoveringTitle] = useState<boolean>(false);
+
+    const styles = useStyles();
+
+    useEffect(() => {
+        // TODO: remember to replace this with localhost before merging
+        axios.get('http://mumapbackend.us-east-1.elasticbeanstalk.com/mural')
+            .then((response) => {
+                if (response.data) setMurals(response.data.murals.rows)
+            })
+            .catch(err => console.log(err));
+    }, []);
+
+    return (
+        <form noValidate autoComplete="off">
+            <div className={styles.flexContainer}>
+                <InputBase
+                    className={`${styles.title} ${styles.field}`}
+                    defaultValue="Name the collection"
+                    onChange={(e: any) => setTitle(e.target.value)}
+                    inputProps={{ 'aria-label': 'New collection title' }}
+                    onClick={() => setEditingTitle(true)}
+                    onBlur={() => setEditingTitle(false)}
+                    onMouseEnter={() => setHoveringTitle(true)}
+                    onMouseLeave={() => setHoveringTitle(false)}
+                    endAdornment={!editingTitle && (
+                        <InputAdornment position="start">
+                            <EditIcon color={hoveringTitle ? "primary" : "action"} />
+                        </InputAdornment>
+                    )}
+                />
+                <InputBase
+                    className={styles.field}
+                    multiline
+                    rows={4}
+                    placeholder="Add a description"
+                    onChange={(e: any) => setDescription(e.target.value)}
+                    onClick={() => setEditingDesc(true)}
+                    onBlur={() => setEditingDesc(false)}
+                    onMouseEnter={() => setHoveringDesc(true)}
+                    onMouseLeave={() => setHoveringDesc(false)}
+                    endAdornment={!editingDesc && (
+                        <InputAdornment position="start">
+                            <EditIcon color={hoveringDesc ? "primary" : "action"} />
+                        </InputAdornment>
+                    )}
+                />
+                <div className={styles.field}>
+                    <SearchBar
+                        searchCallBack={(e: any) => console.log(e)}
+                    />
+                </div>
+            </div>
+        </form>
+    )
+}
+
+export default CollectionForm

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -3,6 +3,7 @@ import {
   InputAdornment,
   InputBase,
   makeStyles,
+  Snackbar,
   TextField,
   Theme
 } from "@material-ui/core";
@@ -12,6 +13,7 @@ import EditIcon from '@material-ui/icons/Edit';
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import ActionButtons from "../ActionButtons/ActionButtons";
 import SearchCard from "SideBarSearch/searchCard";
+import Alert from "@material-ui/lab/Alert";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -47,6 +49,8 @@ function CollectionForm() {
   const [editingTitle, setEditingTitle] = useState<boolean>(false);
   const [hoveringTitle, setHoveringTitle] = useState<boolean>(false);
 
+  const [popup, setPopup] = useState<boolean>(false);
+
   const styles = useStyles();
 
   const handleAddMural = (addedMural: any) => {
@@ -58,6 +62,8 @@ function CollectionForm() {
   };
 
   const handleSave = () => {
+    if (!title.length || !description.length) return;
+
     // TODO: remember to replace this with localhost before merging
     axios.post('http://mumapbackend.us-east-1.elasticbeanstalk.com/collection', {
       collection: {
@@ -66,7 +72,10 @@ function CollectionForm() {
       },
       murals: muralsInCollection.map((mural: any) => mural.id)
     })
-      .then((response: any) => { console.log("Collection added!") })
+      .then(() => {
+        setPopup(true);
+        setTimeout(() => setPopup(false), 5000);
+      })
       .catch((err: any) => console.log(err));
   };
 
@@ -151,6 +160,11 @@ function CollectionForm() {
       </form>
       <SearchCard searchCards={muralsInCollection} />
       <ActionButtons saveCallback={handleSave} cancelCallback={handleCancel} />
+      <Snackbar open={popup} autoHideDuration={6000}>
+        <Alert severity="success">
+          Collection published successfully!
+        </Alert>
+      </Snackbar>
     </div>
   )
 }

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -11,6 +11,7 @@ import axios from "axios";
 import React, { SyntheticEvent, useEffect, useState } from "react";
 import EditIcon from '@material-ui/icons/Edit';
 import Autocomplete from "@material-ui/lab/Autocomplete";
+import ActionButtons from "../ActionButtons/ActionButtons";
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -28,18 +29,6 @@ const useStyles = makeStyles((theme: Theme) =>
         },
         title: {
             fontSize: "180%",
-        },
-        bottomButton: {
-            margin: theme.spacing(0, 0, 0, 3)
-        },
-        bottomButtonContainer: {
-            display: "flex",
-            justifyContent: "flex-end",
-            padding: theme.spacing(3),
-            width: "40vw",
-            maxWidth: "500px",
-            position: "fixed",
-            bottom: 0
         },
     })
 );
@@ -153,26 +142,7 @@ function CollectionForm() {
                     </div>
                 </div>
             </form>
-            <div className={styles.bottomButtonContainer}>
-                <Button
-                    color="secondary"
-                    size="small"
-                    variant="outlined"
-                    className={styles.bottomButton}
-                    onClick={handleCancel}
-                >
-                    Cancel
-                </Button>
-                <Button
-                    color="primary"
-                    size="small"
-                    variant="contained"
-                    disableElevation
-                    className={styles.bottomButton}
-                    onClick={handleSave}>
-                    Save
-                </Button>
-            </div>
+            <ActionButtons saveCallback={handleSave} cancelCallback={handleCancel} />
         </div>
     )
 }

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -1,150 +1,158 @@
 import {
-    Button,
-    createStyles,
-    InputAdornment,
-    InputBase,
-    makeStyles,
-    TextField,
-    Theme
+  createStyles,
+  InputAdornment,
+  InputBase,
+  makeStyles,
+  TextField,
+  Theme
 } from "@material-ui/core";
 import axios from "axios";
 import React, { SyntheticEvent, useEffect, useState } from "react";
 import EditIcon from '@material-ui/icons/Edit';
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import ActionButtons from "../ActionButtons/ActionButtons";
+import SearchCard from "SideBarSearch/searchCard";
 
 const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        flexContainer: {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "start",
-            width: "40vw",
-            maxWidth: "500px",
-            padding: theme.spacing(3)
-        },
-        field: {
-            width: "100%",
-            margin: theme.spacing(2, 0, 2, 0)
-        },
-        title: {
-            fontSize: "180%",
-        },
-    })
+  createStyles({
+    flexContainer: {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "start",
+      width: "40vw",
+      maxWidth: "500px",
+      padding: theme.spacing(3)
+    },
+    field: {
+      width: "100%",
+      margin: theme.spacing(0, 0, 2, 0)
+    },
+    title: {
+      fontSize: "180%",
+    },
+  })
 );
 
 function CollectionForm() {
-    const [murals, setMurals] = useState<any>([]);
-    const [muralsInCollection, setMuralsInCollection] = useState<any>([]);
-    const [muralResults, setMuralResults] = useState<any>([]);
-    const [muralQuery, setMuralQuery] = useState<string>("");
+  const [murals, setMurals] = useState<any>([]);
+  const [muralsInCollection, setMuralsInCollection] = useState<any>([]);
+  const [muralResults, setMuralResults] = useState<any>([]);
+  const [muralQuery, setMuralQuery] = useState<string>("");
 
-    const [description, setDescription] = useState([]);
-    const [editingDesc, setEditingDesc] = useState<boolean>(false);
-    const [hoveringDesc, setHoveringDesc] = useState<boolean>(false);
+  const [description, setDescription] = useState([]);
+  const [editingDesc, setEditingDesc] = useState<boolean>(false);
+  const [hoveringDesc, setHoveringDesc] = useState<boolean>(false);
 
-    const [title, setTitle] = useState([]);
-    const [editingTitle, setEditingTitle] = useState<boolean>(false);
-    const [hoveringTitle, setHoveringTitle] = useState<boolean>(false);
+  const [title, setTitle] = useState([]);
+  const [editingTitle, setEditingTitle] = useState<boolean>(false);
+  const [hoveringTitle, setHoveringTitle] = useState<boolean>(false);
 
-    const styles = useStyles();
+  const styles = useStyles();
 
-    const handleAddMural = (addedMural: any) => {
-        if (!addedMural) return
-        if (muralsInCollection.some((currMural: any) => currMural.id === addedMural.id))
-            return
+  const handleAddMural = (addedMural: any) => {
+    if (!addedMural) return
+    if (muralsInCollection.some((currMural: any) => currMural.id === addedMural.id))
+      return
 
-        setMuralsInCollection((oldMurals: any) => [...oldMurals, addedMural]);
-    };
+    setMuralsInCollection((oldMurals: any) => [...oldMurals, addedMural]);
+  };
 
-    const handleSave = () => {
-        console.log(title)
-        console.log(description)
-        console.log(muralsInCollection)
-    };
+  const handleSave = () => {
+    // TODO: remember to replace this with localhost before merging
+    axios.post('http://mumapbackend.us-east-1.elasticbeanstalk.com/collection', {
+      collection: {
+        name: title,
+        description: description
+      },
+      murals: muralsInCollection.map((mural: any) => mural.id)
+    })
+      .then((response: any) => { console.log("Collection added!") })
+      .catch((err: any) => console.log(err));
+  };
 
-    const handleCancel = () => {
-        console.log("cancel")
-    };
+  const handleCancel = () => {
+    console.log("cancel")
+  };
 
-    useEffect(() => {
-        // TODO: remember to replace this with localhost before merging
-        axios.get('http://mumapbackend.us-east-1.elasticbeanstalk.com/mural')
-            .then((response) => {
-                if (response.data) setMurals(response.data.murals.rows)
-            })
-            .catch(err => console.log(err));
-    }, []);
+  useEffect(() => {
+    // TODO: remember to replace this with localhost before merging
+    axios.get('http://mumapbackend.us-east-1.elasticbeanstalk.com/mural')
+      .then((response) => {
+        if (response.data) setMurals(response.data.murals.rows)
+      })
+      .catch(err => console.log(err));
+  }, []);
 
-    useEffect(() => {
-        const filtered = murals.filter((mural: any) => {
-            return mural.name.toLowerCase().includes(muralQuery)
-        });
-        setMuralResults(filtered);
-    }, [muralQuery, murals]);
+  useEffect(() => {
+    const filtered = murals.filter((mural: any) => {
+      return mural.name.toLowerCase().includes(muralQuery)
+    });
+    setMuralResults(filtered);
+  }, [muralQuery, murals]);
 
-    return (
-        <div>
-            <form
-                noValidate
-                autoComplete="off"
-                onSubmit={(e: SyntheticEvent) => { e.preventDefault(); handleSave() }}>
-                <div className={styles.flexContainer}>
-                    <InputBase
-                        className={`${styles.title} ${styles.field}`}
-                        defaultValue="Name the collection"
-                        onChange={(e: any) => setTitle(e.target.value)}
-                        inputProps={{ 'aria-label': 'New collection title' }}
-                        onClick={() => setEditingTitle(true)}
-                        onBlur={() => setEditingTitle(false)}
-                        onMouseEnter={() => setHoveringTitle(true)}
-                        onMouseLeave={() => setHoveringTitle(false)}
-                        endAdornment={!editingTitle && (
-                            <InputAdornment position="start">
-                                <EditIcon color={hoveringTitle ? "primary" : "action"} />
-                            </InputAdornment>
-                        )}
-                    />
-                    <InputBase
-                        className={styles.field}
-                        multiline
-                        rows={4}
-                        placeholder="Add a description"
-                        onChange={(e: any) => setDescription(e.target.value)}
-                        onClick={() => setEditingDesc(true)}
-                        onBlur={() => setEditingDesc(false)}
-                        onMouseEnter={() => setHoveringDesc(true)}
-                        onMouseLeave={() => setHoveringDesc(false)}
-                        endAdornment={!editingDesc && (
-                            <InputAdornment position="start">
-                                <EditIcon color={hoveringDesc ? "primary" : "action"} />
-                            </InputAdornment>
-                        )}
-                    />
-                    <div className={styles.field}>
-                        <Autocomplete
-                            freeSolo
-                            options={muralResults.map((mural: any) => mural)}
-                            getOptionLabel={(mural: any) => mural.name}
-                            onChange={(e: any, value: any) => handleAddMural(value)}
-                            renderInput={(params) => (
-                                <TextField
-                                    {...params}
-                                    label="Add a mural"
-                                    variant="outlined"
-                                    size="small"
-                                    onChange={
-                                        (e: any) => setMuralQuery(e.target.value.toLowerCase())
-                                    }
-                                />
-                            )}
-                        />
-                    </div>
-                </div>
-            </form>
-            <ActionButtons saveCallback={handleSave} cancelCallback={handleCancel} />
+  return (
+    <div>
+      <form
+        noValidate
+        autoComplete="off"
+        onSubmit={(e: SyntheticEvent) => { e.preventDefault(); handleSave() }}>
+        <div className={styles.flexContainer}>
+          <InputBase
+            className={`${styles.title} ${styles.field}`}
+            defaultValue="Name the collection"
+            onChange={(e: any) => setTitle(e.target.value)}
+            inputProps={{ 'aria-label': 'New collection title' }}
+            onClick={() => setEditingTitle(true)}
+            onBlur={() => setEditingTitle(false)}
+            onMouseEnter={() => setHoveringTitle(true)}
+            onMouseLeave={() => setHoveringTitle(false)}
+            endAdornment={!editingTitle && (
+              <InputAdornment position="start">
+                <EditIcon color={hoveringTitle ? "primary" : "action"} />
+              </InputAdornment>
+            )}
+          />
+          <InputBase
+            className={styles.field}
+            multiline
+            rows={4}
+            placeholder="Add a description"
+            onChange={(e: any) => setDescription(e.target.value)}
+            onClick={() => setEditingDesc(true)}
+            onBlur={() => setEditingDesc(false)}
+            onMouseEnter={() => setHoveringDesc(true)}
+            onMouseLeave={() => setHoveringDesc(false)}
+            endAdornment={!editingDesc && (
+              <InputAdornment position="start">
+                <EditIcon color={hoveringDesc ? "primary" : "action"} />
+              </InputAdornment>
+            )}
+          />
+          <div className={styles.field}>
+            <Autocomplete
+              freeSolo
+              options={muralResults.map((mural: any) => mural)}
+              getOptionLabel={(mural: any) => mural.name}
+              onChange={(e: any, value: any) => handleAddMural(value)}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Add a mural"
+                  variant="outlined"
+                  size="small"
+                  onChange={
+                    (e: any) => setMuralQuery(e.target.value.toLowerCase())
+                  }
+                />
+              )}
+            />
+          </div>
         </div>
-    )
+      </form>
+      <SearchCard searchCards={muralsInCollection} />
+      <ActionButtons saveCallback={handleSave} cancelCallback={handleCancel} />
+    </div>
+  )
 }
 
-export default CollectionForm
+export default CollectionForm;

--- a/frontend/src/SideBarSearch/searchCard.tsx
+++ b/frontend/src/SideBarSearch/searchCard.tsx
@@ -4,68 +4,69 @@ import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        flexContainer: {
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flexStart",
-        },
-        card: {
-            width: "450px",
-            margin: "5%",
-            display: "flex",
-        },
-        icon: {
-            width: '27%',
-            height: '100%',
-        },
-        properties: {
-            marginLeft: '5%',
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'spaceBetween',
-            width: '30%',
-        },
-        type: {
-            marginLeft: theme.spacing(9)
-        }
-    }),
+  createStyles({
+    flexContainer: {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "flexStart",
+      width: "100%",
+      maxWidth: "450px"
+    },
+    card: {
+      margin: theme.spacing(0, 2, 2, 3),
+      display: "flex",
+      justifyContent: "flex-start"
+    },
+    icon: {
+      maxWidth: "25%",
+      height: "100%"
+    },
+    properties: {
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "space-between",
+      padding: theme.spacing(0, 0, 1, 2),
+      width: "50%"
+    },
+    type: {
+      margin: theme.spacing(1, 0, 0, 1),
+      color: theme.palette.error.main
+    }
+  }),
 );
 
 interface ISearchCardProps {
-    searchCards: any;
+  searchCards: any;
 }
 
 function SearchCard(props: ISearchCardProps) {
-    const styles = useStyles();
+  const styles = useStyles();
 
-    return (
-        <div className={styles.flexContainer}>
-            {
-                props.searchCards.map((mural: any, index: any) => {
-
-                    return (<Card className={styles.card}>
-
-                        <img className={styles.icon}
-                            src="https://cdn2.lamag.com/wp-content/uploads/sites/6/2020/01/kobe-mural-mr-brainwash-chris-delmas-afp-getty-1068x712.jpg"
-                            alt="mural"></img>
-                        <div className={styles.properties}>
-                            <Typography variant="subtitle1">
-                                {mural.name}
-                            </Typography>
-                            <Typography variant="body2">
-                                {mural.address}, {mural.city}
-                            </Typography>
-
-                        </div>
-                        <Typography variant="body1" className={styles.type}>
-                            mural
-                        </Typography>
-                    </Card>)
-                })
-            }
-        </div>
-    );
+  return (
+    <div className={styles.flexContainer}>
+      {props.searchCards.map((mural: any, index: any) => {
+        return (
+          <Card className={styles.card} key={mural.id}>
+            <img className={styles.icon}
+              src="https://cdn2.lamag.com/wp-content/uploads/sites/6/2020/01/kobe-mural-mr-brainwash-chris-delmas-afp-getty-1068x712.jpg"
+              alt="mural"></img>
+            <div className={styles.properties}>
+              <Typography variant="subtitle1">
+                {mural.name}
+              </Typography>
+              <Typography variant="body2">
+                {mural.address}, {mural.city}
+              </Typography>
+            </div>
+            <Typography variant="body1" className={styles.type}>
+              mural
+            </Typography>
+          </Card>
+        )
+      })
+      }
+    </div>
+  );
 }
 
 export default SearchCard;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2491,6 +2491,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+JSONSelect@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/JSONSelect/-/JSONSelect-0.4.0.tgz#a08edcc67eb3fcbe99ed630855344a0cf282bb8d"
+  integrity sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40=
+
 abab@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -2843,6 +2848,11 @@ atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+augment@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/augment/-/augment-3.2.1.tgz#ec5d9e9456140efab1110fddb352cbe54e7fb31c"
+  integrity sha1-7F2elFYUDvqxEQ/ds1LL5U5/sxw=
 
 autoprefixer@^9.6.1:
   version "9.8.6"
@@ -3745,6 +3755,11 @@ colorette@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
+
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
+  integrity sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -4677,6 +4692,11 @@ earcut@^2.2.2:
   resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.2.tgz#41b0bc35f63e0fe80da7cddff28511e7e2e80d11"
   integrity sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ==
 
+ebnf-parser@0.1.x:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/ebnf-parser/-/ebnf-parser-0.1.10.tgz#cd1f6ba477c5638c40c97ed9b572db5bab5d8331"
+  integrity sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE=
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -4904,6 +4924,16 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escodegen@0.0.21:
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-0.0.21.tgz#53d652cfa1030388279458a5266c5ffc709c63c3"
+  integrity sha1-U9ZSz6EDA4gnlFilJmxf/HCcY8M=
+  dependencies:
+    esprima "~1.0.2"
+    estraverse "~0.0.4"
+  optionalDependencies:
+    source-map ">= 0.1.2"
+
 escodegen@^1.14.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
@@ -5115,6 +5145,11 @@ espree@^7.3.0:
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.3.0"
 
+esprima@1.0.x, esprima@~1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
+  integrity sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=
+
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -5143,6 +5178,11 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+
+estraverse@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-0.0.4.tgz#01a0932dfee574684a598af5a67c3bf9b6428db2"
+  integrity sha1-AaCTLf7ldGhKWYr1pnw7+bZCjbI=
 
 estree-walker@^0.6.1:
   version "0.6.1"
@@ -7284,6 +7324,27 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
+jison-lex@0.2.x:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jison-lex/-/jison-lex-0.2.1.tgz#ac4b815e8cce5132eb12b5dfcfe8d707b8844dfe"
+  integrity sha1-rEuBXozOUTLrErXfz+jXB7iETf4=
+  dependencies:
+    lex-parser "0.1.x"
+    nomnom "1.5.2"
+
+jison@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/jison/-/jison-0.4.4.tgz#86b03b65efec007a91f493eceabe56f90aa6b439"
+  integrity sha1-hrA7Ze/sAHqR9JPs6r5W+QqmtDk=
+  dependencies:
+    JSONSelect "0.4.0"
+    ebnf-parser "0.1.x"
+    escodegen "0.0.21"
+    esprima "1.0.x"
+    jison-lex "0.2.x"
+    lex-parser "0.1.x"
+    nomnom "1.5.2"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -7626,6 +7687,16 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lex-parser@0.1.x:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/lex-parser/-/lex-parser-0.1.4.tgz#64c4f025f17fd53bfb45763faeb16f015a747550"
+  integrity sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA=
+
+lex@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/lex/-/lex-1.7.4.tgz#33dd66b980a38d77a6c424d7173e6f40d602c0c5"
+  integrity sha1-M91muYCjjXemxCTXFz5vQNYCwMU=
 
 line-column@^1.0.2:
   version "1.0.2"
@@ -8308,6 +8379,14 @@ node-releases@^1.1.61:
   version "1.1.64"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.64.tgz#71b4ae988e9b1dd7c1ffce58dd9e561752dfebc5"
   integrity sha512-Iec8O9166/x2HRMJyLLLWkd0sFFLrFNy+Xf+JQfSQsdBJzPcHpNl3JQ9gD4j+aJxmCa25jNsIbM4bmACtSbkSg==
+
+nomnom@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.5.2.tgz#f4345448a853cfbd5c0d26320f2477ab0526fe2f"
+  integrity sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=
+  dependencies:
+    colors "0.5.x"
+    underscore "1.1.x"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -10151,6 +10230,16 @@ regex-parser@^2.2.11:
   resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.11.tgz#3b37ec9049e19479806e878cabe7c1ca83ccfe58"
   integrity sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==
 
+regex@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/regex/-/regex-0.1.1.tgz#0580995d1846c5376a762b9d358b83068d207aef"
+  integrity sha1-BYCZXRhGxTdqdiudNYuDBo0geu8=
+  dependencies:
+    augment "3.2.1"
+    jison "0.4.4"
+    lex "1.7.4"
+    statemachines "0.1.0"
+
 regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz#7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75"
@@ -10859,6 +10948,11 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sorted-array@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sorted-array/-/sorted-array-1.1.0.tgz#61a98325e412bb90999b4bac18dfed5f3564102d"
+  integrity sha1-YamDJeQSu5CZm0usGN/tXzVkEC0=
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -10901,15 +10995,15 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, sourc
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+"source-map@>= 0.1.2", source-map@^0.7.3, source-map@~0.7.2:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
-
-source-map@^0.7.3, source-map@~0.7.2:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 sourcemap-codec@^1.4.4:
   version "1.4.8"
@@ -11022,6 +11116,14 @@ stackframe@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
   integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
+
+statemachines@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/statemachines/-/statemachines-0.1.0.tgz#b545fd3d8a55280f302b8696f19c0a11c4e33ade"
+  integrity sha1-tUX9PYpVKA8wK4aW8ZwKEcTjOt4=
+  dependencies:
+    augment "3.2.1"
+    sorted-array "1.1.0"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -11669,6 +11771,11 @@ typescript@~4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
   integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+
+underscore@1.1.x:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.1.7.tgz#40bab84bad19d230096e8d6ef628bff055d83db0"
+  integrity sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA=
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
# Summary

Add collection form based on the new Figma:

- Add fields for `title`, `description`, and a `mural` search bar
- Since fields aren't outlined, show a coloured pencil icon when the user hovers over an editable field
- Loop over and render @yi-fang-yuan 's `searchCard`s with the added murals
- Show a success badge when a collection is successfully `POST`ed

Some other fun stuff:

- Add an `ActionButtons` component in the process, which takes a `cancel` and `save` callback
- Adjust sidebar CSS to match new Figma

To do:

- Handle cancel button event to close sidebar
- Parametrize field values as props to allow a pin to be loaded into the form
- Parametrize whether the fields can be edited

## Test Plan

Some screenshots:
<img width="400" alt="Screen Shot 2021-02-01 at 3 55 42 PM" src="https://user-images.githubusercontent.com/36117635/106833643-e2ed5e80-6661-11eb-9f61-00596c788d9e.png">

<img width="300" alt="Screen Shot 2021-02-01 at 3 55 42 PM" src="https://user-images.githubusercontent.com/36117635/106833732-116b3980-6662-11eb-809e-c2ce7c4f3a9e.png">

## Related Issues

Closes #85 