### PR TITLE
Update map styling

### DIFF
--- a/frontend/src/Map/Map.css
+++ b/frontend/src/Map/Map.css
@@ -1,7 +1,0 @@
-.mapContainer {
-    position: absolute;
-    top: 0;
-    right: 0;
-    left: 0;
-    bottom: 0;
-    }

--- a/frontend/src/Map/Map.tsx
+++ b/frontend/src/Map/Map.tsx
@@ -4,10 +4,23 @@ import {
   DEFAULT_LONGITUDE,
   DEFAULT_LATITUDE,
   DEFAULT_ZOOM,
+  MAPBOX_STYLE_URL
 } from "constants/constants";
-import "./Map.css";
+import { createStyles, makeStyles, Theme } from "@material-ui/core";
 
 mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_TOKEN || "";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    container: {
+      position: "absolute",
+      left: 0,
+      top: 0,
+      bottom: 0,
+      right: 0
+    }
+  })
+);
 
 interface IMapProps {
   mapContainer: HTMLElement | string | null;
@@ -15,20 +28,23 @@ interface IMapProps {
 }
 
 function Map({ mapContainer, murals }: IMapProps) {
+
+  const styles = useStyles();
+
   const [lng, setLng] = useState(DEFAULT_LONGITUDE);
   const [lat, setLat] = useState(DEFAULT_LATITUDE);
   const [zoom, setZoom] = useState(DEFAULT_ZOOM);
 
-
   useEffect(() => {
     const map = new mapboxgl.Map({
       container: (mapContainer as any),
-      style: "mapbox://styles/mapbox/streets-v11",
+      style: MAPBOX_STYLE_URL,
       center: [lng, lat],
       zoom: zoom,
       attributionControl: false
     });
 
+    map.addControl(new mapboxgl.NavigationControl(), 'bottom-right');
     map.addControl(
       new mapboxgl.GeolocateControl({
         positionOptions: {
@@ -38,7 +54,6 @@ function Map({ mapContainer, murals }: IMapProps) {
       }),
       'bottom-right'
     );
-
     map.addControl(new mapboxgl.AttributionControl(), 'top-left');
 
     map.on("move", () => {
@@ -48,7 +63,7 @@ function Map({ mapContainer, murals }: IMapProps) {
     });
 
     murals.forEach((mural: any) => {
-      new mapboxgl.Marker()
+      new mapboxgl.Marker({ color: "#FC323E" })
         .setLngLat([
           mural.coordinates.coordinates[0],
           mural.coordinates.coordinates[1],
@@ -59,9 +74,7 @@ function Map({ mapContainer, murals }: IMapProps) {
   }, [murals]);
 
   return (
-    <div>
-      <div ref={(el) => (mapContainer = el)} className="mapContainer" />
-    </div>
+    <div ref={(el) => (mapContainer = el)} className={styles.container} />
   );
 }
 

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -13,6 +13,8 @@ export const MTL_MAX_LONGITUDE = -73.33952;
 export const MTL_MAX_LATITUDE = 45.752154;
 export const MAPBOX_GEOCODING_API =
   "https://api.mapbox.com/geocoding/v5/mapbox.places/";
-export const GET_ALL_ARTISTS_API = "http://localhost:3000/artist";
-export const GET_ALL_BOROUGH_API = "http://localhost:3000/borough";
-export const CREATE_MURAL_API = "http://localhost:3000/mural";
+export const MAPBOX_STYLE_URL =
+  "mapbox://styles/mumap/ckhb8l6je01ki1ao4tabh8e2q";
+export const GET_ALL_ARTISTS_API = "localhost:3000/artist";
+export const GET_ALL_BOROUGH_API = "localhost:3000/borough";
+export const CREATE_MURAL_API = "localhost:3000/mural";


### PR DESCRIPTION
# Summary

- Replaced default Mapbox styles with MU's map style
- Added Mapbox NavigationControls (see below)
- Updated marker colour to reflect Figma

<img width="350" src="https://user-images.githubusercontent.com/36117635/108154745-78014600-70ab-11eb-8b10-46a300bc6751.png">


## Test Plan

Ran in the browser

## Related Issues

Closes #96 
Did it for the _momentum_ 🏃‍♂️ 