### PR TITLE
Feature/87 open mural from pin

### DIFF
--- a/frontend/src/AddressSearch/addressSearch.tsx
+++ b/frontend/src/AddressSearch/addressSearch.tsx
@@ -24,6 +24,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 interface IAddressSearchBarProps {
+  defaultAddress?: string;
   callback: (coords: number[], address: string, neighbourhood: string) => void;
 }
 
@@ -99,6 +100,7 @@ export default function AddressSearchBar(props: IAddressSearchBarProps) {
         loading={loading}
         id="address-search-bar"
         options={options}
+        defaultValue={props.defaultAddress}
         filterOptions={(options) => options}
         onOpen={() => {
           setOpen(true);

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -16,15 +16,19 @@ import { CREATE_MURAL_API, FORM } from "constants/constants";
 import LeaveWarning from "components/LeaveWarning";
 
 function App() {
+
   const [isSignedIn, setIsSignedIn] = useState<boolean>(false);
   const [signingIn, setSigningIn] = useState<boolean>(false);
-  const [user, setUser] = useState<any>({});
-  const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
-  const [murals, setMurals] = useState<any>([]);
-  const [searchResult, setSearchResult] = useState<any>([]);
   const [signInError, setSignInError] = useState<string>("");
+  const [user, setUser] = useState<any>({});
+
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
+  const [searchResult, setSearchResult] = useState<any>([]);
   const [activeForm, setActiveForm] = useState<FORM>(FORM.MURAL);
   const [formWarning, setFormWarning] = useState<boolean>(false);
+
+  const [murals, setMurals] = useState<any>([]);
+  const [selectedMarker, setSelectedMarker] = useState<any>({} as any);
 
   const handleSignin = (creds: any) => {
     setSignInError("");
@@ -84,6 +88,10 @@ function App() {
   };
 
   useEffect(() => {
+    console.log(selectedMarker)
+  }, [selectedMarker]);
+
+  useEffect(() => {
     getMural();
   }, []);
 
@@ -99,7 +107,9 @@ function App() {
           open={signingIn}
         />
         <Search searchCallBack={handleSearch} />
-        <Map murals={murals} mapContainer={document.getElementById("root")} />
+        <Map
+          murals={murals}
+          markerClick={(marker: any) => setSelectedMarker(marker)} />
         <DropdownMenu
           isSignedIn={isSignedIn}
           signinClick={openSignin}

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -28,7 +28,7 @@ function App() {
   const [formWarning, setFormWarning] = useState<boolean>(false);
 
   const [murals, setMurals] = useState<any>([]);
-  const [selectedMural, setSelectedMural] = useState<any>({} as any);
+  const [selectedMural, setSelectedMural] = useState<any>(null);
 
   const handleSignin = (creds: any) => {
     setSignInError("");

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -134,7 +134,7 @@ function App() {
         <LeaveWarning
           open={formWarning}
           handleStay={() => setFormWarning(false)}
-          handleLeave={leaveForm} />
+          handleLeave={() => { leaveForm(); setSelectedMural(null) }} />
         <PlusButton isVisible={true} handleClick={toggleSidebar} />
       </Context.Provider>
     </div>

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -87,6 +87,9 @@ function App() {
     setMurals(data.rows);
   };
 
+  /**
+   * When a mural marker is clicked, open the mural form
+   */
   useEffect(() => {
     if (!selectedMural) return;
     toggleSidebar(FORM.MURAL);

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -28,7 +28,7 @@ function App() {
   const [formWarning, setFormWarning] = useState<boolean>(false);
 
   const [murals, setMurals] = useState<any>([]);
-  const [selectedMarker, setSelectedMarker] = useState<any>({} as any);
+  const [selectedMural, setSelectedMural] = useState<any>({} as any);
 
   const handleSignin = (creds: any) => {
     setSignInError("");
@@ -88,8 +88,11 @@ function App() {
   };
 
   useEffect(() => {
-    console.log(selectedMarker)
-  }, [selectedMarker]);
+    console.log(selectedMural)
+    if (!selectedMural) return;
+    toggleSidebar(FORM.MURAL);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedMural]);
 
   useEffect(() => {
     getMural();
@@ -109,7 +112,7 @@ function App() {
         <Search searchCallBack={handleSearch} />
         <Map
           murals={murals}
-          markerClick={(marker: any) => setSelectedMarker(marker)} />
+          muralClick={(mural: any) => setSelectedMural(mural)} />
         <DropdownMenu
           isSignedIn={isSignedIn}
           signinClick={openSignin}
@@ -123,7 +126,7 @@ function App() {
           {searchResult.length ? (
             <SearchCard searchCards={searchResult} />
           ) : activeForm === FORM.MURAL ? (
-            <MuralForm handleCancel={toggleSidebar} />
+            <MuralForm mural={selectedMural} handleCancel={toggleSidebar} />
           ) : activeForm === FORM.COLLECTION ? (
             <CollectionForm handleCancel={toggleSidebar} />
           ) : null}

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -88,7 +88,6 @@ function App() {
   };
 
   useEffect(() => {
-    console.log(selectedMural)
     if (!selectedMural) return;
     toggleSidebar(FORM.MURAL);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -112,7 +111,8 @@ function App() {
         <Search searchCallBack={handleSearch} />
         <Map
           murals={murals}
-          muralClick={(mural: any) => setSelectedMural(mural)} />
+          muralClick={(mural: any) => setSelectedMural(mural)}
+        />
         <DropdownMenu
           isSignedIn={isSignedIn}
           signinClick={openSignin}

--- a/frontend/src/ArtistSearch/ArtistSearch.tsx
+++ b/frontend/src/ArtistSearch/ArtistSearch.tsx
@@ -44,6 +44,10 @@ export default function ArtistSearchBar(props: IArtistSearchBarProps) {
     setResult(filtered);
   }, [query, artists]);
 
+  /**
+   * If a default artistId prop is supplied, find the corresponding
+   * artist's name
+   */
   useEffect(() => {
     if (props.defaultArtist && artists.length > 0) {
       const filtered: any = artists.filter((artist: any) => {

--- a/frontend/src/ArtistSearch/ArtistSearch.tsx
+++ b/frontend/src/ArtistSearch/ArtistSearch.tsx
@@ -59,6 +59,7 @@ export default function ArtistSearchBar(props: IArtistSearchBarProps) {
       return result.name.toLowerCase().includes(newValue.toLowerCase());
     });
     if (filtered.length === 0) props.callback(null);
+    setDefaultName(filtered[0].name);
     props.callback(filtered[0].id);
   }
 
@@ -67,7 +68,7 @@ export default function ArtistSearchBar(props: IArtistSearchBarProps) {
       <Autocomplete
         freeSolo={false}
         disableClearable
-        value={defaultName ? defaultName : null}
+        value={defaultName || null}
         options={result.map((artist: any) => artist.name)}
         onChange={(event: any, newValue: string) => {
           getIdAndCallback(newValue);

--- a/frontend/src/ArtistSearch/ArtistSearch.tsx
+++ b/frontend/src/ArtistSearch/ArtistSearch.tsx
@@ -17,6 +17,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 interface IArtistSearchBarProps {
+  defaultArtist?: number;
   callback: (artistId: number | null) => void;
 }
 
@@ -25,6 +26,7 @@ export default function ArtistSearchBar(props: IArtistSearchBarProps) {
   const [query, setQuery] = useState("");
   const classes = useStyles();
   const [result, setResult] = useState([]);
+  const [defaultName, setDefaultName] = useState("");
 
   useEffect(() => {
     axios
@@ -42,6 +44,15 @@ export default function ArtistSearchBar(props: IArtistSearchBarProps) {
     setResult(filtered);
   }, [query, artists]);
 
+  useEffect(() => {
+    if (props.defaultArtist && artists.length > 0) {
+      const filtered: any = artists.filter((artist: any) => {
+        return artist.id === props.defaultArtist
+      })
+      setDefaultName(filtered[0].name);
+    }
+  }, [props.defaultArtist, artists]);
+
   function getIdAndCallback(newValue: string) {
     // results has a default max size of 5 I believe, so this is O(1)
     const filtered: any = result.filter((result: any) => {
@@ -56,6 +67,7 @@ export default function ArtistSearchBar(props: IArtistSearchBarProps) {
       <Autocomplete
         freeSolo={false}
         disableClearable
+        value={defaultName ? defaultName : null}
         options={result.map((artist: any) => artist.name)}
         onChange={(event: any, newValue: string) => {
           getIdAndCallback(newValue);

--- a/frontend/src/BoroughSearch/BoroughSearch.tsx
+++ b/frontend/src/BoroughSearch/BoroughSearch.tsx
@@ -44,6 +44,10 @@ export default function BoroughSearchBar(props: IBoroughSearchBarProps) {
     setResult(filtered);
   }, [query, boroughs]);
 
+  /**
+   * If a default boroughId prop is supplied, find the corresponding
+   * borough's name
+   */
   useEffect(() => {
     if (props.defaultBorough && boroughs.length > 0) {
       const filtered: any = boroughs.filter((borough: any) => {

--- a/frontend/src/BoroughSearch/BoroughSearch.tsx
+++ b/frontend/src/BoroughSearch/BoroughSearch.tsx
@@ -17,6 +17,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 interface IBoroughSearchBarProps {
+  defaultBorough?: string;
   callback: (boroughId: number | null) => void;
 }
 
@@ -25,6 +26,7 @@ export default function BoroughSearchBar(props: IBoroughSearchBarProps) {
   const [query, setQuery] = useState("");
   const classes = useStyles();
   const [result, setResult] = useState([]);
+  const [defaultName, setDefaultName] = useState("");
 
   useEffect(() => {
     axios
@@ -42,12 +44,22 @@ export default function BoroughSearchBar(props: IBoroughSearchBarProps) {
     setResult(filtered);
   }, [query, boroughs]);
 
+  useEffect(() => {
+    if (props.defaultBorough && boroughs.length > 0) {
+      const filtered: any = boroughs.filter((borough: any) => {
+        return borough.id === props.defaultBorough
+      })
+      setDefaultName(filtered[0].name);
+    }
+  }, [props.defaultBorough, boroughs])
+
   function getIdAndCallback(newValue: string) {
     // results has a default max size of 5 I believe, so this is O(1)
     const filtered: any = result.filter((result: any) => {
       return result.name.toLowerCase().includes(newValue.toLowerCase());
     });
     if (filtered.length === 0) props.callback(null);
+    setDefaultName(filtered[0].name);
     props.callback(filtered[0].id);
   }
 
@@ -56,6 +68,7 @@ export default function BoroughSearchBar(props: IBoroughSearchBarProps) {
       <Autocomplete
         freeSolo={false}
         disableClearable
+        value={defaultName || null}
         options={result.map((borough: any) => borough.name)}
         onChange={(event: any, newValue: string) => {
           getIdAndCallback(newValue);

--- a/frontend/src/ImageUpload/ImageUpload.tsx
+++ b/frontend/src/ImageUpload/ImageUpload.tsx
@@ -120,7 +120,7 @@ function ImageUpload({
     if (imgsUrlAndPath.length % 2 === 1) {
       return (
         <div className={styles.imageCard}>
-          </div>
+        </div>
       )
     }
   }
@@ -133,26 +133,28 @@ function ImageUpload({
         <input type="file" hidden onChange={handleUpload} accept="image/*" />
       </Button>
       <div className={styles.imageContainer}>
-      {imgsUrlAndPath.map((urlAndPath) => {
-        return (
-          <div className={styles.imageCard}>
-              <IconButton
+        {imgsUrlAndPath.map((urlAndPath) => {
+          return (
+            <div
+              className={styles.imageCard}
               key={urlAndPath.url + "_"}
-              onClick={() => handleRemove(urlAndPath.path)}
-              className={styles.deleteButton}
             >
-              <HighlightOffOutlinedIcon color="secondary" />
-            </IconButton>
-            <img
-              alt="mural"
-              className={styles.muralImage}
-              key={urlAndPath.url}
-              src={urlAndPath.url}
-            ></img>
-          </div>
-        );
-      })}
-      {dummyImage(imgsUrlAndPath)}
+              <IconButton
+                onClick={() => handleRemove(urlAndPath.path)}
+                className={styles.deleteButton}
+              >
+                <HighlightOffOutlinedIcon color="secondary" />
+              </IconButton>
+              <img
+                alt="mural"
+                className={styles.muralImage}
+                key={urlAndPath.url}
+                src={urlAndPath.url}
+              />
+            </div>
+          );
+        })}
+        {dummyImage(imgsUrlAndPath)}
       </div>
     </div>
   );

--- a/frontend/src/Map/Map.tsx
+++ b/frontend/src/Map/Map.tsx
@@ -11,15 +11,16 @@ import {
 } from "constants/constants";
 import "./Map.css";
 import mapboxgl from "mapbox-gl";
+import { Typography } from "@material-ui/core";
 // eslint-disable-next-line import/no-webpack-loader-syntax
 (mapboxgl as any).workerClass = require("worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker").default;
 
 interface IMapProps {
-  markerClick: (marker: any) => void;
+  muralClick: (mural: any) => void;
   murals: any;
 }
 
-function Map({ markerClick, murals }: IMapProps) {
+function Map({ muralClick, murals }: IMapProps) {
 
   const [viewport, setViewport] = useState({
     width: "100vw",
@@ -68,14 +69,18 @@ function Map({ markerClick, murals }: IMapProps) {
         >
           <img style={imgStyle} src={popupInfo.ImgURLs} alt="Mural_img" ></img>
           <p>
-            <h3> {popupInfo.name} </h3>
+            <Typography variant="h5" gutterBottom>
+              {popupInfo.name}
+            </Typography>
             {popupInfo.address}
           </p>
           <Button
             variant="outlined"
             disableElevation
             color="primary"
-            onClick={() => markerClick(popupInfo)}>DETAILS</Button>
+            onClick={() => muralClick(popupInfo)}>
+            DETAILS
+          </Button>
         </Popup>
       )
       }

--- a/frontend/src/Map/Map.tsx
+++ b/frontend/src/Map/Map.tsx
@@ -65,7 +65,6 @@ function Map({ muralClick, murals }: IMapProps) {
           longitude={popupInfo.coordinates.coordinates[0]}
           latitude={popupInfo.coordinates.coordinates[1]}
           closeOnClick={false}
-          captureDrag={true}
           onClose={setPopupInfo}
         >
           <img style={imgStyle} src={popupInfo.ImgURLs} alt="Mural_img" ></img>

--- a/frontend/src/Map/Map.tsx
+++ b/frontend/src/Map/Map.tsx
@@ -65,15 +65,19 @@ function Map({ muralClick, murals }: IMapProps) {
           longitude={popupInfo.coordinates.coordinates[0]}
           latitude={popupInfo.coordinates.coordinates[1]}
           closeOnClick={false}
+          captureDrag={true}
           onClose={setPopupInfo}
         >
           <img style={imgStyle} src={popupInfo.ImgURLs} alt="Mural_img" ></img>
-          <p>
+          <div>
             <Typography variant="h5" gutterBottom>
               {popupInfo.name}
             </Typography>
-            {popupInfo.address}
-          </p>
+            <Typography variant="caption">
+              {popupInfo.address}
+            </Typography>
+          </div>
+          <br />
           <Button
             variant="outlined"
             disableElevation

--- a/frontend/src/Map/Map.tsx
+++ b/frontend/src/Map/Map.tsx
@@ -10,17 +10,16 @@ import {
   MAPBOX_STYLE_URL,
 } from "constants/constants";
 import "./Map.css";
-
 import mapboxgl from "mapbox-gl";
 // eslint-disable-next-line import/no-webpack-loader-syntax
 (mapboxgl as any).workerClass = require("worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker").default;
 
 interface IMapProps {
-  mapContainer: HTMLElement | string | null;
+  markerClick: (marker: any) => void;
   murals: any;
 }
 
-function Map({ mapContainer, murals }: IMapProps) {
+function Map({ markerClick, murals }: IMapProps) {
 
   const [viewport, setViewport] = useState({
     width: "100vw",
@@ -43,7 +42,6 @@ function Map({ mapContainer, murals }: IMapProps) {
   };
 
   const [popupInfo, setPopupInfo] = useState<any>([]);
-  // const [editMural, setEditMural] = useState<any>([]); -> For the EDIT button of the popup
 
   return (
     <ReactMapGL
@@ -71,9 +69,13 @@ function Map({ mapContainer, murals }: IMapProps) {
           <img style={imgStyle} src={popupInfo.ImgURLs} alt="Mural_img" ></img>
           <p>
             <h3> {popupInfo.name} </h3>
-            {popupInfo.address} </p>
-          {/* <Button variant="contained" color="primary" onClick={() => setEditMural(popupInfo)}>EDIT</Button> */}
-          <Button variant="contained" color="primary" >EDIT</Button>
+            {popupInfo.address}
+          </p>
+          <Button
+            variant="outlined"
+            disableElevation
+            color="primary"
+            onClick={() => markerClick(popupInfo)}>DETAILS</Button>
         </Popup>
       )
       }

--- a/frontend/src/Map/Map.tsx
+++ b/frontend/src/Map/Map.tsx
@@ -67,7 +67,7 @@ function Map({ muralClick, murals }: IMapProps) {
           closeOnClick={false}
           onClose={setPopupInfo}
         >
-          <img style={imgStyle} src={popupInfo.ImgURLs} alt="Mural_img" ></img>
+          <img style={imgStyle} src={popupInfo.imgURLs?.[0]} alt="Mural_img" ></img>
           <div>
             <Typography variant="h5" gutterBottom>
               {popupInfo.name}

--- a/frontend/src/Map/Map.tsx
+++ b/frontend/src/Map/Map.tsx
@@ -39,7 +39,7 @@ function Map({ muralClick, murals }: IMapProps) {
   const imgStyle = {
     maxWidth: '200px',
     maxHeight: '200px',
-    padding: 'none'
+    paddingBottom: '10px'
   };
 
   const [popupInfo, setPopupInfo] = useState<any>([]);

--- a/frontend/src/multiAdd/MultiAdd.tsx
+++ b/frontend/src/multiAdd/MultiAdd.tsx
@@ -29,9 +29,7 @@ interface IMultiAddProps {
 
 function MultiAdd(props: IMultiAddProps) {
   const styles = useStyles();
-  const [items, setItems] = useState<string[]>(
-    props.defaultItems ? props.defaultItems : []
-  );
+  const [items, setItems] = useState<string[]>(props.defaultItems || []);
   const [currentInput, setCurrentInput] = useState<string>("");
 
   function addItem() {

--- a/frontend/src/multiAdd/MultiAdd.tsx
+++ b/frontend/src/multiAdd/MultiAdd.tsx
@@ -23,12 +23,15 @@ const useStyles = makeStyles((theme: Theme) =>
 interface IMultiAddProps {
   title: string;
   placeholder: string;
+  defaultItems?: string[];
   callback: (items: string[]) => void;
 }
 
 function MultiAdd(props: IMultiAddProps) {
   const styles = useStyles();
-  const [items, setItems] = useState<string[]>([]);
+  const [items, setItems] = useState<string[]>(
+    props.defaultItems ? props.defaultItems : []
+  );
   const [currentInput, setCurrentInput] = useState<string>("");
 
   function addItem() {

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -193,16 +193,19 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
           <MultiAdd
             title={"Assistants"}
             placeholder={"Add assistants..."}
+            defaultItems={mural?.assistants}
             callback={(newAssistants: string[]) => setAssistants(newAssistants)}
           />
           <MultiAdd
             title={"Partners"}
             placeholder={"Add partners..."}
+            defaultItems={mural?.partners}
             callback={(newPartners: string[]) => setPartners(newPartners)}
           />
           <MultiAdd
             title={"Social Media"}
             placeholder={"Add social media..."}
+            defaultItems={mural?.socialMediaURLs}
             callback={(newSocialMedia: string[]) =>
               setSocialMedia(newSocialMedia)
             }

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -40,16 +40,19 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 interface IMuralFormProps {
+  mural?: any;
   handleCancel: () => void;
 }
 
-function MuralForm({ handleCancel }: IMuralFormProps) {
+function MuralForm({ mural, handleCancel }: IMuralFormProps) {
 
   const styles = useStyles();
 
   const [name, setName] = useState<string>("");
   const [description, setDescription] = useState<string>("");
-  const [year, setYear] = useState<number>(new Date().getFullYear());
+  const [year, setYear] = useState<number>(mural ?
+    mural.year : new Date().getFullYear()
+  );
 
   const [address, setAddress] = useState<string>("");
   const [addressCoords, setAddressCoords] = useState<number[]>([]);
@@ -60,7 +63,6 @@ function MuralForm({ handleCancel }: IMuralFormProps) {
   const [socialMedia, setSocialMedia] = useState<string[]>([]);
   const [partners, setPartners] = useState<string[]>([]);
   const [artist, setArtist] = useState<number | null>(null);
-
 
   const [editingName, setEditingName] = useState<boolean>(false);
   const [hoveringName, setHoveringName] = useState<boolean>(false);
@@ -134,6 +136,7 @@ function MuralForm({ handleCancel }: IMuralFormProps) {
             required={true}
             placeholder="Name the mural"
             id="name"
+            defaultValue={mural?.name}
             inputProps={{ "aria-label": "naked" }}
             onChange={(e: any) => setName(e.target.value)}
             onClick={() => setEditingName(true)}
@@ -153,6 +156,7 @@ function MuralForm({ handleCancel }: IMuralFormProps) {
             multiline
             rows={4}
             id="description"
+            defaultValue={mural?.description}
             placeholder="Add a description"
             inputProps={{ "aria-label": "naked" }}
             onChange={(e: any) => setDescription(e.target.value)}
@@ -186,7 +190,7 @@ function MuralForm({ handleCancel }: IMuralFormProps) {
           <ArtistSearchBar
             callback={(artistId: number | null) => setArtist(artistId)}
           />
-          <MultiAdd // TODO not sure how to make these borderless
+          <MultiAdd
             title={"Assistants"}
             placeholder={"Add assistants..."}
             callback={(newAssistants: string[]) => setAssistants(newAssistants)}

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -198,6 +198,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
           />
           <AddressSearch callback={handleAddressUpdate} />
           <BoroughSearchBar
+            defaultBorough={mural?.boroughId}
             callback={(boroughId: number | null) => setBorough(boroughId)}
           />
           <ArtistSearchBar

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -77,7 +77,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
     setYear(mural.year);
     setAddress(mural.address);
     setAddressCoords(mural.coordinates.coordinates);
-    setBorough(mural.borough);
+    setBorough(mural.boroughId);
     setNeighbourhood(mural.neighbourhood);
     setAssistants(mural.assistants);
     setSocialMedia(mural.socialMediaURLs);
@@ -102,32 +102,49 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
       alert("Please check validity of address.");
       return;
     }
-    axios
-      .post(CREATE_MURAL_API, {
-        name: name,
-        boroughId: borough,
-        artistId: artist,
-        year: year,
-        city: "Montreal",
-        longitude: addressCoords[0],
-        latitude: addressCoords[1],
-        assistants: assistants,
-        partners: partners,
-        description: description,
-        socialMedia: socialMedia,
-        address: address,
-        neighbourhood: neighbourhood,
-      })
-      .then(
-        (response) => {
-          console.log(response);
-          setPopup(true);
-          setTimeout(() => setPopup(false), 5000);
-        },
-        (error) => {
-          console.log(error);
-        }
-      );
+    let payload = {
+      name: name,
+      boroughId: borough,
+      artistId: artist,
+      year: year,
+      city: "Montreal",
+      longitude: addressCoords[0],
+      latitude: addressCoords[1],
+      assistants: assistants,
+      partners: partners,
+      description: description,
+      socialMedia: socialMedia,
+      address: address,
+      neighbourhood: neighbourhood,
+    } as any;
+    if (mural && Object.keys(mural)) {
+      payload.id = mural.id;
+      axios
+        .put(`${CREATE_MURAL_API}/${payload.id}`, payload)
+        .then(
+          (response) => {
+            console.log(response);
+            setPopup(true);
+            setTimeout(() => setPopup(false), 5000);
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
+    } else {
+      axios
+        .post(CREATE_MURAL_API, payload)
+        .then(
+          (response) => {
+            console.log(response);
+            setPopup(true);
+            setTimeout(() => setPopup(false), 5000);
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
+    }
   }
 
   function handleAddressUpdate(

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -102,6 +102,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
       alert("Please check validity of address.");
       return;
     }
+
     let payload = {
       name: name,
       boroughId: borough,
@@ -117,34 +118,24 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
       address: address,
       neighbourhood: neighbourhood,
     } as any;
-    if (mural && Object.keys(mural)) {
-      payload.id = mural.id;
-      axios
-        .put(`${CREATE_MURAL_API}/${payload.id}`, payload)
-        .then(
-          (response) => {
-            console.log(response);
-            setPopup(true);
-            setTimeout(() => setPopup(false), 5000);
-          },
-          (error) => {
-            console.log(error);
-          }
-        );
-    } else {
-      axios
-        .post(CREATE_MURAL_API, payload)
-        .then(
-          (response) => {
-            console.log(response);
-            setPopup(true);
-            setTimeout(() => setPopup(false), 5000);
-          },
-          (error) => {
-            console.log(error);
-          }
-        );
-    }
+    let existingMural = mural && Object.keys(mural);
+    if (existingMural) payload.id = mural.id;
+    axios({
+      method: existingMural ? 'put' : 'post',
+      url: existingMural ?
+        `${CREATE_MURAL_API}/${payload.id}` : CREATE_MURAL_API,
+      data: payload
+    })
+      .then(
+        (response) => {
+          console.log(response);
+          setPopup(true);
+          setTimeout(() => setPopup(false), 5000);
+        },
+        (error) => {
+          console.log(error);
+        }
+      );
   }
 
   function handleAddressUpdate(

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { InputBase, InputAdornment, Typography, Snackbar } from "@material-ui/core";
 import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 import AddressSearch from "../AddressSearch/addressSearch";
@@ -50,9 +50,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
 
   const [name, setName] = useState<string>("");
   const [description, setDescription] = useState<string>("");
-  const [year, setYear] = useState<number>(mural ?
-    mural.year : new Date().getFullYear()
-  );
+  const [year, setYear] = useState<number>(new Date().getFullYear());
 
   const [address, setAddress] = useState<string>("");
   const [addressCoords, setAddressCoords] = useState<number[]>([]);
@@ -71,6 +69,21 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
   const [hoveringDesc, setHoveringDesc] = useState<boolean>(false);
 
   const [popup, setPopup] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!mural || !Object.keys(mural)) return;
+    setName(mural.name);
+    setDescription(mural.description);
+    setYear(mural.year);
+    setAddress(mural.address);
+    setAddressCoords(mural.coordinates.coordinates);
+    setBorough(mural.borough);
+    setNeighbourhood(mural.neighbourhood);
+    setAssistants(mural.assistants);
+    setSocialMedia(mural.socialMediaURLs);
+    setPartners(mural.partners);
+    setArtist(mural.artistId);
+  }, [mural])
 
   function submitForm() {
     if (name === "") {
@@ -179,7 +192,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             required
             id="year"
             type="number"
-            defaultValue={year}
+            defaultValue={mural?.year}
             inputProps={{ "aria-label": "naked" }}
             onChange={(e: any) => setYear(e.target.value)}
           />

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -196,7 +196,10 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             inputProps={{ "aria-label": "naked" }}
             onChange={(e: any) => setYear(e.target.value)}
           />
-          <AddressSearch callback={handleAddressUpdate} />
+          <AddressSearch
+            defaultAddress={mural?.address}
+            callback={handleAddressUpdate}
+          />
           <BoroughSearchBar
             defaultBorough={mural?.boroughId}
             callback={(boroughId: number | null) => setBorough(boroughId)}

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -201,6 +201,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             callback={(boroughId: number | null) => setBorough(boroughId)}
           />
           <ArtistSearchBar
+            defaultArtist={mural?.artistId}
             callback={(artistId: number | null) => setArtist(artistId)}
           />
           <MultiAdd

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -97,6 +97,13 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
     setSocialMedia(mural.socialMediaURLs);
     setPartners(mural.partners);
     setArtist(mural.artistId);
+    if (mural.imgURLs) {
+      setImgUrlsAndPath(mural.imgURLs.map(
+        (url: string) => {
+          return { url: url, path: pathFromUrl(url) }
+        }
+      ));
+    }
   }, [mural])
 
   function submitForm() {
@@ -177,6 +184,19 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
     var urlsAndPaths = [...imgUrlsAndPath]
     const newUrlsAndPaths = urlsAndPaths.filter(urlAndPath => pathToRemove !== urlAndPath.path)
     setImgUrlsAndPath(newUrlsAndPaths)
+  }
+
+  /**
+   * Extract the Firebase-friendly path from a URL
+   * @param url download URL of mural image from Firebase Storage
+   */
+  function pathFromUrl(url: string) {
+    let substrings = url.split("/");
+    if (substrings.length < 1) return;
+    let path = substrings[substrings.length - 1].split("?")[0];
+    path = path.replaceAll("%20", " ");
+    path = path.replaceAll("%2F", "/");
+    return path;
   }
 
   return (
@@ -270,7 +290,11 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
           <Typography variant="body1" display="block" color="textSecondary">
             Gallery
           </Typography>
-          <ImageUpload uploadHandler={handleImgUrlAdd} removeHandler={handleImgUrlRemove} imgsUrlAndPath={imgUrlsAndPath}></ImageUpload>
+          <ImageUpload
+            uploadHandler={handleImgUrlAdd}
+            removeHandler={handleImgUrlRemove}
+            imgsUrlAndPath={imgUrlsAndPath}
+          />
         </div>
       </form>
       <ActionButtons saveCallback={submitForm} cancelCallback={handleCancel} />


### PR DESCRIPTION
# Summary

- Open the mural form and populate its fields when a mural marker's `Details` button is clicked
- Store the selected mural in App.tsx's state
- Pass default values from the mural to textfields
- Passing defaults values to `multiAdd`s was a bit messier
- Set muralForm's `axios` method to `PUT` when it has an existing mural

To do:

- Newly-created murals do not show up right away as pins 📍  Two options would be to update the client-side data or to push updates to all clients when the server is updated.
- Social media URLs don't seem to be `POST`ing

## Test Plan

- Verify form values against raw mural data via Postman
- Ensure the form is reset after being closed
- Try editing different murals and the same mural more than once

<img width="400" alt="Screen Shot 2021-02-22 at 6 49 02 PM" src="https://user-images.githubusercontent.com/36117635/108785034-a4e7aa00-753e-11eb-920b-5a71e1ad6a54.png">

## Related Issues

Closes #87 