### PR TITLE
Feature/135 admin features

### DIFF
--- a/frontend/src/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/ActionButtons/ActionButtons.tsx
@@ -4,7 +4,8 @@ import {
   makeStyles,
   Theme,
 } from "@material-ui/core";
-import React from "react";
+import React, { useContext, useEffect, useState } from "react";
+import Context from "context";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -31,6 +32,14 @@ function ActionButtons({ saveCallback, cancelCallback }: IActionButtonsProps) {
 
   const styles = useStyles();
 
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+
+  /**
+   * Show cancel and save buttons for admin users
+   */
+  const userContext = useContext(Context)
+  useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
+
   const handleSave = () => {
     saveCallback()
   };
@@ -41,7 +50,9 @@ function ActionButtons({ saveCallback, cancelCallback }: IActionButtonsProps) {
 
   return (
     <div className={styles.bottomButtonContainer}>
-      <Button
+      {
+        isAdmin &&
+        <Button
         color="secondary"
         size="small"
         variant="outlined"
@@ -49,16 +60,20 @@ function ActionButtons({ saveCallback, cancelCallback }: IActionButtonsProps) {
         onClick={handleCancel}
       >
         Cancel
-      </Button>
-      <Button
-        color="primary"
-        size="small"
-        variant="contained"
-        disableElevation
-        className={styles.bottomButton}
-        onClick={handleSave}>
-        Save
-      </Button>
+        </Button>
+      }
+      {
+        isAdmin &&
+        <Button
+          color="primary"
+          size="small"
+          variant="contained"
+          disableElevation
+          className={styles.bottomButton}
+          onClick={handleSave}>
+          Save
+        </Button>
+      }
     </div>
   )
 }

--- a/frontend/src/AddressSearch/addressSearch.tsx
+++ b/frontend/src/AddressSearch/addressSearch.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import axios from "axios";
 import { makeStyles } from "@material-ui/core/styles";
 import TextField from "@material-ui/core/TextField";
@@ -12,6 +12,8 @@ import {
   MTL_MIN_LATITUDE,
 } from "../constants/constants";
 import CircularProgress from "@material-ui/core/CircularProgress";
+import Context from "context";
+import { Typography } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -35,6 +37,8 @@ export default function AddressSearchBar(props: IAddressSearchBarProps) {
   const [options, setOptions] = useState([]);
   const [response, setResponse] = useState([]);
   const loading = open && options.length === 0;
+
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
   useEffect(() => {
     let active = true;
@@ -79,6 +83,12 @@ export default function AddressSearchBar(props: IAddressSearchBarProps) {
     }
   }, [open]);
 
+  /**
+   * Enable editing for admin users
+   */
+  const userContext = useContext(Context)
+  useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
+
   function updateCoordinates(selection: string) {
     const filtered: any = response.filter((option: any) => {
       return option.place_name === selection;
@@ -93,47 +103,56 @@ export default function AddressSearchBar(props: IAddressSearchBarProps) {
 
   return (
     <div className={styles.root}>
-      <Autocomplete
-        freeSolo={false}
-        disableClearable
-        open={open}
-        loading={loading}
-        id="address-search-bar"
-        options={options}
-        defaultValue={props.defaultAddress}
-        filterOptions={(options) => options}
-        onOpen={() => {
-          setOpen(true);
-        }}
-        onClose={() => {
-          setOpen(false);
-        }}
-        onChange={(event: any, selection: string) =>
-          updateCoordinates(selection)
-        }
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            id="autocomplete-text-f"
-            label="Address"
-            variant="outlined"
-            size="small"
-            placeholder="Type at least two characters"
-            onChange={(e) => setQuery(e.target.value.toLowerCase())}
-            InputProps={{
-              ...params.InputProps,
-              endAdornment: (
-                <Fragment>
-                  {loading ? (
-                    <CircularProgress color="inherit" size={20} />
-                  ) : null}
-                  {params.InputProps.endAdornment}
-                </Fragment>
-              ),
+      {
+        isAdmin ? (
+          <Autocomplete
+            freeSolo={false}
+            disableClearable
+            open={open}
+            loading={loading}
+            id="address-search-bar"
+            options={options}
+            defaultValue={props.defaultAddress}
+            filterOptions={(options) => options}
+            onOpen={() => {
+              setOpen(true);
             }}
+            onClose={() => {
+              setOpen(false);
+            }}
+            onChange={(event: any, selection: string) =>
+              updateCoordinates(selection)
+            }
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                id="autocomplete-text-f"
+                label="Address"
+                variant="outlined"
+                size="small"
+                placeholder="Type at least two characters"
+                onChange={(e) => setQuery(e.target.value.toLowerCase())}
+                InputProps={{
+                  ...params.InputProps,
+                  endAdornment: (
+                    <Fragment>
+                      {loading ? (
+                        <CircularProgress color="inherit" size={20} />
+                      ) : null}
+                      {params.InputProps.endAdornment}
+                    </Fragment>
+                  ),
+                }}
+              />
+            )}
           />
-        )}
-      />
+          ) : (
+          <div>
+            <Typography variant="caption" color="textSecondary">Address</Typography>
+            <Typography variant="body1">{props.defaultAddress}</Typography>
+          </div>
+        )
+      }
     </div>
   );
 }

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -31,7 +31,6 @@ function App() {
   const [welcomeOpen, setWelcomeOpen] = useState<boolean>(true);
 
   const [murals, setMurals] = useState<any>([]);
-  const [resourceType, setResourceType] = useState<FORM>(FORM.MURAL);
   const [selectedResource, setSelectedResource] = useState<any>(null);
 
   const [tours, setTours] = useState<any>([]);
@@ -73,8 +72,15 @@ function App() {
 
   const handleCancelSignin = () => setSigningIn(false);
 
+  /**
+   * If opening the sidebar, set the appropriate form type.
+   * If closing the sidebar and signed in, warn the admin
+   * to save progress.
+   * @param formName Type of form to be opened in the sidebar
+   */
   const toggleSidebar = (formName: FORM = FORM.MURAL) => {
-    if (sidebarOpen) return setFormWarning(true);
+    if (sidebarOpen && isSignedIn) return setFormWarning(true);
+    else if (sidebarOpen) return leaveForm();
     setSidebarOpen(!sidebarOpen);
     formName && setActiveForm(formName);
   };
@@ -115,9 +121,7 @@ function App() {
    * When a resource marker is clicked, open its respective form
    */
   useEffect(() => {
-    if (selectedResource) {
-      toggleSidebar(resourceType);
-    }
+    if (selectedResource) toggleSidebar(activeForm);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedResource]);
 
@@ -149,7 +153,10 @@ function App() {
         <Map
           tours={tours}
           murals={murals}
-          muralClick={(mural: any) => setSelectedResource(mural)}
+          muralClick={(mural: any) => {
+            setActiveForm(FORM.MURAL);
+            setSelectedResource(mural);
+          }}
           ref={mapRef}
         />
         <DropdownMenu
@@ -174,17 +181,14 @@ function App() {
               handleMuralClick={handleSearchedMuralZoom}
               handleCancel={toggleSidebarNoWarning}
               setSelectedResource={setSelectedResource}
-              setResourceType={setResourceType}
+              setResourceType={setActiveForm}
             />
           )}
         </Sidebar>
         <LeaveWarning
           open={formWarning}
           handleStay={() => setFormWarning(false)}
-          handleLeave={() => {
-            leaveForm();
-            setSelectedResource(null);
-          }}
+          handleLeave={leaveForm}
         />
         <PlusButton isVisible={true} handleClick={toggleSidebar} />
       </Context.Provider>

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -187,7 +187,7 @@ function App() {
           handleStay={() => setFormWarning(false)}
           handleLeave={leaveForm}
         />
-        <PlusButton isVisible={true} handleClick={toggleSidebar} />
+        <PlusButton isVisible={isSignedIn} handleClick={toggleSidebar} />
       </Context.Provider>
     </div>
   );

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -85,13 +85,10 @@ function App() {
     formName && setActiveForm(formName);
   };
 
-  const toggleSidebarNoWarning = () => {
-    setSidebarOpen(!sidebarOpen);
-  };
-
   const leaveForm = () => {
     setSidebarOpen(false);
     setFormWarning(false);
+    // setSelectedResource(null);
   };
 
   const getMural = async () => {
@@ -121,7 +118,7 @@ function App() {
    * When a resource marker is clicked, open its respective form
    */
   useEffect(() => {
-    if (selectedResource) toggleSidebar(activeForm);
+    if (selectedResource && !sidebarOpen) toggleSidebar(activeForm);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedResource]);
 
@@ -179,7 +176,7 @@ function App() {
           ) : (
             <SearchMenu
               handleMuralClick={handleSearchedMuralZoom}
-              handleCancel={toggleSidebarNoWarning}
+              handleCancel={leaveForm}
               setSelectedResource={setSelectedResource}
               setResourceType={setActiveForm}
             />

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -88,7 +88,6 @@ function App() {
   const leaveForm = () => {
     setSidebarOpen(false);
     setFormWarning(false);
-    // setSelectedResource(null);
   };
 
   const getMural = async () => {

--- a/frontend/src/ArtistSearch/ArtistSearch.tsx
+++ b/frontend/src/ArtistSearch/ArtistSearch.tsx
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { useContext } from "react";
 import axios from "axios";
 import { makeStyles } from "@material-ui/core/styles";
 import TextField from "@material-ui/core/TextField";
 import { useState, useEffect } from "react";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import { GET_ALL_ARTISTS_API } from "../constants/constants"
+import Context from "context";
+import { Typography } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -27,6 +29,8 @@ export default function ArtistSearchBar(props: IArtistSearchBarProps) {
   const classes = useStyles();
   const [result, setResult] = useState([]);
   const [defaultName, setDefaultName] = useState("");
+
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
   useEffect(() => {
     axios
@@ -57,6 +61,12 @@ export default function ArtistSearchBar(props: IArtistSearchBarProps) {
     }
   }, [props.defaultArtist, artists]);
 
+  /**
+   * Enable editing for admin users
+   */
+  const userContext = useContext(Context)
+  useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
+
   function getIdAndCallback(newValue: string) {
     // results has a default max size of 5 I believe, so this is O(1)
     const filtered: any = result.filter((result: any) => {
@@ -69,26 +79,35 @@ export default function ArtistSearchBar(props: IArtistSearchBarProps) {
 
   return (
     <div className={classes.root}>
-      <Autocomplete
-        freeSolo={false}
-        disableClearable
-        value={defaultName || null}
-        options={result.map((artist: any) => artist.name)}
-        onChange={(event: any, newValue: string) => {
-          getIdAndCallback(newValue);
-        }}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            id="search-artist"
-            label="Artist"
-            variant="outlined"
-            size="small"
-            placeholder="Who made it?"
-            onChange={(e) => setQuery(e.target.value.toLowerCase())}
+      {
+        isAdmin ? (
+          <Autocomplete
+            freeSolo={false}
+            disableClearable
+            value={defaultName || null}
+            options={result.map((artist: any) => artist.name)}
+            onChange={(event: any, newValue: string) => {
+              getIdAndCallback(newValue);
+            }}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                id="search-artist"
+                label="Artist"
+                variant="outlined"
+                size="small"
+                placeholder="Who made it?"
+                onChange={(e) => setQuery(e.target.value.toLowerCase())}
+              />
+            )}
           />
-        )}
-      />
+        ) : (
+          <div>
+            <Typography variant="caption" color="textSecondary">Artist</Typography>
+            <Typography variant="body1">{defaultName}</Typography>
+          </div>
+        )
+      }
     </div>
   );
 }

--- a/frontend/src/BoroughSearch/BoroughSearch.tsx
+++ b/frontend/src/BoroughSearch/BoroughSearch.tsx
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { useContext } from "react";
 import axios from "axios";
 import { makeStyles } from "@material-ui/core/styles";
 import TextField from "@material-ui/core/TextField";
 import { useState, useEffect } from "react";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import { GET_ALL_BOROUGH_API } from "../constants/constants";
+import Context from "context";
+import { Typography } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -27,6 +29,8 @@ export default function BoroughSearchBar(props: IBoroughSearchBarProps) {
   const classes = useStyles();
   const [result, setResult] = useState([]);
   const [defaultName, setDefaultName] = useState("");
+
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
   useEffect(() => {
     axios
@@ -57,6 +61,12 @@ export default function BoroughSearchBar(props: IBoroughSearchBarProps) {
     }
   }, [props.defaultBorough, boroughs])
 
+  /**
+   * Enable editing for admin users
+   */
+  const userContext = useContext(Context)
+  useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
+  
   function getIdAndCallback(newValue: string) {
     // results has a default max size of 5 I believe, so this is O(1)
     const filtered: any = result.filter((result: any) => {
@@ -69,26 +79,35 @@ export default function BoroughSearchBar(props: IBoroughSearchBarProps) {
 
   return (
     <div className={classes.root}>
-      <Autocomplete
-        freeSolo={false}
-        disableClearable
-        value={defaultName || null}
-        options={result.map((borough: any) => borough.name)}
-        onChange={(event: any, newValue: string) => {
-          getIdAndCallback(newValue);
-        }}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            id="search-borough"
-            label="Borough"
-            variant="outlined"
-            size="small"
-            placeholder="Choose a borough"
-            onChange={(e) => setQuery(e.target.value.toLowerCase())}
+      {
+        isAdmin ? (
+          <Autocomplete
+            freeSolo={false}
+            disableClearable
+            value={defaultName || null}
+            options={result.map((borough: any) => borough.name)}
+            onChange={(event: any, newValue: string) => {
+              getIdAndCallback(newValue);
+            }}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                id="search-borough"
+                label="Borough"
+                variant="outlined"
+                size="small"
+                placeholder="Choose a borough"
+                onChange={(e) => setQuery(e.target.value.toLowerCase())}
+              />
+            )}
           />
-        )}
-      />
+        ) : (
+          <div>
+            <Typography variant="caption" color="textSecondary">Borough</Typography>
+            <Typography variant="body1">{defaultName}</Typography>
+          </div>
+        )
+      }
     </div>
   );
 }

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -8,13 +8,14 @@ import {
   Theme
 } from "@material-ui/core";
 import axios from "axios";
-import React, { SyntheticEvent, useEffect, useState } from "react";
+import React, { SyntheticEvent, useContext, useEffect, useState } from "react";
 import EditIcon from '@material-ui/icons/Edit';
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import ActionButtons from "../ActionButtons/ActionButtons";
 import SearchCard from "SideBarSearch/searchCard";
 import Alert from "@material-ui/lab/Alert";
 import { CREATE_MURAL_API, GET_ALL_COLLECTION } from "constants/constants";
+import Context from "context";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -58,6 +59,8 @@ function CollectionForm({ collection, muralsData, handleCancel }: ICollectionFor
 
   const [popup, setPopup] = useState<boolean>(false);
 
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+
   const styles = useStyles();
 
   /**
@@ -77,7 +80,13 @@ function CollectionForm({ collection, muralsData, handleCancel }: ICollectionFor
       temp = ([...temp, found]);
     })
     setMuralsInCollection(temp);
-  }, [collection, murals])  
+  }, [collection, murals]);
+
+  /**
+   * Enable editable form fields for admin users
+   */
+  const userContext = useContext(Context)
+  useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
 
   const handleAddMural = (addedMural: any) => {
     if (!addedMural) return
@@ -134,13 +143,14 @@ function CollectionForm({ collection, muralsData, handleCancel }: ICollectionFor
             className={`${styles.title} ${styles.field}`}
             placeholder="Name the collection"
             defaultValue={collection?.name}
+            disabled={!isAdmin}
             onChange={(e: any) => setTitle(e.target.value)}
             inputProps={{ 'aria-label': 'New collection title' }}
             onClick={() => setEditingTitle(true)}
             onBlur={() => setEditingTitle(false)}
             onMouseEnter={() => setHoveringTitle(true)}
             onMouseLeave={() => setHoveringTitle(false)}
-            endAdornment={!editingTitle && (
+            endAdornment={!editingTitle && isAdmin && (
               <InputAdornment position="start">
                 <EditIcon color={hoveringTitle ? "primary" : "action"} />
               </InputAdornment>
@@ -152,35 +162,39 @@ function CollectionForm({ collection, muralsData, handleCancel }: ICollectionFor
             rows={4}
             placeholder="Add a description"
             defaultValue={collection?.description}
+            disabled={!isAdmin}
             onChange={(e: any) => setDescription(e.target.value)}
             onClick={() => setEditingDesc(true)}
             onBlur={() => setEditingDesc(false)}
             onMouseEnter={() => setHoveringDesc(true)}
             onMouseLeave={() => setHoveringDesc(false)}
-            endAdornment={!editingDesc && (
+            endAdornment={!editingDesc && isAdmin && (
               <InputAdornment position="start">
                 <EditIcon color={hoveringDesc ? "primary" : "action"} />
               </InputAdornment>
             )}
           />
           <div className={styles.field}>
-            <Autocomplete
-              freeSolo={false}
-              options={muralResults.map((mural: any) => mural)}
-              getOptionLabel={(mural: any) => mural.name}
-              onChange={(e: any, value: any) => handleAddMural(value)}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Add a mural"
-                  variant="outlined"
-                  size="small"
-                  onChange={
-                    (e: any) => setMuralQuery(e.target.value.toLowerCase())
-                  }
-                />
-              )}
-            />
+            {
+              isAdmin && (
+                <Autocomplete
+                  freeSolo={false}
+                  options={muralResults.map((mural: any) => mural)}
+                  getOptionLabel={(mural: any) => mural.name}
+                  onChange={(e: any, value: any) => handleAddMural(value)}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Add a mural"
+                      variant="outlined"
+                      size="small"
+                      onChange={
+                        (e: any) => setMuralQuery(e.target.value.toLowerCase())
+                      }
+                    />
+                  )}
+                />)
+            }
           </div>
         </div>
       </form>

--- a/frontend/src/ImageUpload/ImageUpload.tsx
+++ b/frontend/src/ImageUpload/ImageUpload.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Button, IconButton } from "@material-ui/core";
 import {
   makeStyles,
@@ -9,6 +9,7 @@ import { FirebaseStorage } from "../firebase/index";
 import "firebase/storage";
 import firebase from "firebase/app";
 import HighlightOffOutlinedIcon from "@material-ui/icons/HighlightOffOutlined";
+import Context from "context";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -63,6 +64,15 @@ function ImageUpload({
   imgsUrlAndPath,
 }: IImageUpload) {
   const styles = useStyles();
+
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+  
+  /**
+   * Enable image deletion for admin users
+   */
+  const userContext = useContext(Context)
+  useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
+
   function handleUpload(event: any) {
     const image = event.target.files[0];
     if (image) {
@@ -127,11 +137,13 @@ function ImageUpload({
 
   return (
     <div className={styles.root}>
-
-      <Button variant="contained" component="label" className={styles.uploadButton}>
-        Upload Mural Picture
-        <input type="file" hidden onChange={handleUpload} accept="image/*" />
-      </Button>
+      {
+        isAdmin &&
+        <Button variant="contained" component="label" className={styles.uploadButton}>
+          Upload Mural Picture
+          <input type="file" hidden onChange={handleUpload} accept="image/*" />
+        </Button>
+      }
       <div className={styles.imageContainer}>
         {imgsUrlAndPath.map((urlAndPath) => {
           return (
@@ -139,12 +151,15 @@ function ImageUpload({
               className={styles.imageCard}
               key={urlAndPath.url + "_"}
             >
+            {
+              isAdmin &&
               <IconButton
                 onClick={() => handleRemove(urlAndPath.path)}
                 className={styles.deleteButton}
-              >
+                >
                 <HighlightOffOutlinedIcon color="secondary" />
               </IconButton>
+              }
               <img
                 alt="mural"
                 className={styles.muralImage}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -64,6 +64,11 @@ let theme = createMuiTheme({
         '@font-face': [avantGarde],
       },
     },
+    MuiInputBase: {
+      root: {
+        '&$disabled': { color: '#000000'}
+      }
+    }
   },
 });
 

--- a/frontend/src/multiAdd/MultiAdd.tsx
+++ b/frontend/src/multiAdd/MultiAdd.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import AddIcon from "@material-ui/icons/Add";
 import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 import InputAdornment from "@material-ui/core/InputAdornment";
 import MultiAddItem from "./MultiAddItem";
 import InputBase from "@material-ui/core/InputBase";
+import Context from "context";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -32,6 +33,8 @@ function MultiAdd(props: IMultiAddProps) {
   const [items, setItems] = useState<string[]>(props.defaultItems || []);
   const [currentInput, setCurrentInput] = useState<string>("");
 
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+
   function addItem() {
     if (currentInput === "") {
       return;
@@ -53,19 +56,27 @@ function MultiAdd(props: IMultiAddProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items]);
 
+  /**
+   * Enable addition for admin users
+   */
+  const userContext = useContext(Context)
+  useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
+
   return (
     <div className={styles.flexContainer}>
-      <InputBase
-        placeholder={props.placeholder}
-        onChange={(e) => setCurrentInput(e.target.value)}
-        value={currentInput}
-        onKeyDown={e => e.key === "Enter" && addItem()}
-        endAdornment={
-          <InputAdornment position="end">
-            <AddIcon className={styles.addIcon} onClick={addItem} />
-          </InputAdornment>
-        }
-      />
+      {isAdmin &&
+        <InputBase
+          placeholder={props.placeholder}
+          onChange={(e) => setCurrentInput(e.target.value)}
+          value={currentInput}
+          onKeyDown={e => e.key === "Enter" && addItem()}
+          endAdornment={
+            <InputAdornment position="end">
+              <AddIcon className={styles.addIcon} onClick={addItem} />
+            </InputAdornment>
+          }
+        />
+      }
       {items.map((item, i) => (
         <MultiAddItem name={item} onDelete={handleItemDelete} key={item} />
       ))}

--- a/frontend/src/multiAdd/MultiAddItem.tsx
+++ b/frontend/src/multiAdd/MultiAddItem.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 import DeleteIcon from "@material-ui/icons/Delete";
 import TextField from "@material-ui/core/TextField";
+import Context from "context";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -27,19 +28,31 @@ interface IMultiAddItemProps {
 function MultiAddItem(props: IMultiAddItemProps) {
   const styles = useStyles();
 
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+  
+  /**
+   * Enable image deletion for admin users
+   */
+  const userContext = useContext(Context)
+  useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
+
   return (
     <div className={styles.itemContainer}>
       <TextField
         defaultValue={props.name}
         size="small"
+        disabled={!isAdmin}
         InputProps={{
           readOnly: true,
         }}
       />
-      <DeleteIcon
+      {
+        isAdmin &&
+        <DeleteIcon
         className={styles.deleteIcon}
         onClick={() => props.onDelete(props.name)}
       />
+      }
     </div>
   );
 }

--- a/frontend/src/multiAdd/MultiAddItem.tsx
+++ b/frontend/src/multiAdd/MultiAddItem.tsx
@@ -31,7 +31,7 @@ function MultiAddItem(props: IMultiAddItemProps) {
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
   
   /**
-   * Enable image deletion for admin users
+   * Enable multi-add item editing and deletion for admin users
    */
   const userContext = useContext(Context)
   useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import {
   InputBase,
   InputAdornment,
@@ -16,6 +16,7 @@ import axios from "axios";
 import { CREATE_MURAL_API } from "../constants/constants";
 import Alert from "@material-ui/lab/Alert";
 import ImageUpload from '../ImageUpload/ImageUpload'
+import Context from "context";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -81,6 +82,14 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
 
   const [popup, setPopup] = useState<boolean>(false);
 
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+
+  /**
+   * Enable editable form fields for admin users
+   */
+  const userContext = useContext(Context)
+  useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
+  
   /**
    * Populate the form when an existing mural is passed as a prop
    */
@@ -209,6 +218,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             placeholder="Name the mural"
             id="name"
             defaultValue={mural?.name}
+            disabled={!isAdmin}
             inputProps={{ "aria-label": "naked" }}
             onChange={(e: any) => setName(e.target.value)}
             onClick={() => setEditingName(true)}
@@ -216,7 +226,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             onMouseEnter={() => setHoveringName(true)}
             onMouseLeave={() => setHoveringName(false)}
             endAdornment={
-              !editingName && (
+              !editingName && isAdmin && (
                 <InputAdornment position="start">
                   <EditIcon color={hoveringName ? "primary" : "action"} />
                 </InputAdornment>
@@ -230,6 +240,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             id="description"
             defaultValue={mural?.description}
             placeholder="Add a description"
+            disabled={!isAdmin}
             inputProps={{ "aria-label": "naked" }}
             onChange={(e: any) => setDescription(e.target.value)}
             onClick={() => setEditingDesc(true)}
@@ -237,7 +248,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             onMouseEnter={() => setHoveringDesc(true)}
             onMouseLeave={() => setHoveringDesc(false)}
             endAdornment={
-              !editingDesc && (
+              !editingDesc && isAdmin && (
                 <InputAdornment position="start">
                   <EditIcon color={hoveringDesc ? "primary" : "action"} />
                 </InputAdornment>
@@ -252,6 +263,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             id="year"
             type="number"
             defaultValue={mural?.year}
+            disabled={!isAdmin}
             inputProps={{ "aria-label": "naked" }}
             onChange={(e: any) => setYear(e.target.value)}
           />

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -255,7 +255,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
               )
             }
           />
-          <Typography variant="body1" display="block" color="textSecondary">
+          <Typography variant="caption" display="block" color="textSecondary">
             Year
           </Typography>
           <InputBase


### PR DESCRIPTION
# Summary

**Hide or disable all features that are for MU eyes only**
It's a thicc PR I know, but you'll see a lot of this:
```
const [isAdmin, setIsAdmin] = useState<boolean>(false);
...
const userContext = useContext(Context)
useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
...
{ isAdmin && <FormField /> }
```
Please let me know if you see a less impactful way to go about this.

- Disable all form fields in the mural, collection, and tour form. Change global `disabled` appearance to black text.
- Replace tour form's drag-and-drop with a list of `SearchCard`s for non-MU users. Hide the `n/25 murals added` text.
- Hide the "leaving form" warning
- Hide the plus button

Out-of-scope but necessary bug fixes
- 🐞 Encountered a bug where, after viewing a tour, the tour form would attempt to re-open when clicking a mural. This was because (of my lack of unit tests - sorry - but also) the callback to open a mural did not update the `activeForm` / `resourceType` (duplicate vars)
- 🐛 Opening a tour from the search bar when signed in would cause the sidebar to close

## Test Plan

- Sign out then open a mural from the map and open a tour/collection/mural from the search bar

<img width="350" alt="Screen Shot 2021-03-27 at 12 49 32 AM" src="https://user-images.githubusercontent.com/36117635/112710294-4e9bbd00-8e96-11eb-8eb3-48fcdb863fa5.png">

<img width="350" alt="Screen Shot 2021-03-27 at 12 49 32 AM" src="https://user-images.githubusercontent.com/36117635/112710429-94a55080-8e97-11eb-823c-3263af79584b.png">

## Related Issues

Closes #135 
