### PR TITLE
Change MultiAddItem to a MaterialUI Chip

### DIFF
--- a/frontend/src/ArtistBoroughSearch.tsx
+++ b/frontend/src/ArtistBoroughSearch.tsx
@@ -58,7 +58,7 @@ export default function ArtistBoroughSearch(props: IArtistBoroughSearchProps) {
       setDefaultSelectionName(filtered[0].name);
     }
   }, [props.defaultSelection, selections]);
-    
+
   /**
    * Enable editing for admin users
    */
@@ -104,7 +104,7 @@ export default function ArtistBoroughSearch(props: IArtistBoroughSearchProps) {
           />
         ) : (
           <div>
-            <Typography variant="caption" color="textSecondary">Artist</Typography>
+            <Typography variant="caption" color="textSecondary">{props.label}</Typography>
             <Typography variant="body1">{defaultSelectionName}</Typography>
           </div>
         )

--- a/frontend/src/multiAdd/MultiAdd.tsx
+++ b/frontend/src/multiAdd/MultiAdd.tsx
@@ -5,6 +5,7 @@ import InputAdornment from "@material-ui/core/InputAdornment";
 import MultiAddItem from "./MultiAddItem";
 import InputBase from "@material-ui/core/InputBase";
 import Context from "context";
+import { Typography } from "@material-ui/core";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -77,6 +78,9 @@ function MultiAdd(props: IMultiAddProps) {
           }
         />
       }
+      {!isAdmin &&
+        items.length !== 0 &&
+        <Typography variant="caption" color="textSecondary"> {props.title}</Typography>}
       {items.map((item, i) => (
         <MultiAddItem name={item} onDelete={handleItemDelete} key={item} />
       ))}

--- a/frontend/src/multiAdd/MultiAddItem.tsx
+++ b/frontend/src/multiAdd/MultiAddItem.tsx
@@ -1,8 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
-import DeleteIcon from "@material-ui/icons/Delete";
-import TextField from "@material-ui/core/TextField";
 import Context from "context";
+import Chip from '@material-ui/core/Chip';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -29,7 +28,7 @@ function MultiAddItem(props: IMultiAddItemProps) {
   const styles = useStyles();
 
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
-  
+
   /**
    * Enable multi-add item editing and deletion for admin users
    */
@@ -38,20 +37,18 @@ function MultiAddItem(props: IMultiAddItemProps) {
 
   return (
     <div className={styles.itemContainer}>
-      <TextField
-        defaultValue={props.name}
-        size="small"
-        disabled={!isAdmin}
-        InputProps={{
-          readOnly: true,
-        }}
-      />
+      {!isAdmin &&
+        <Chip
+          label={props.name}
+        />
+      }
       {
         isAdmin &&
-        <DeleteIcon
-        className={styles.deleteIcon}
-        onClick={() => props.onDelete(props.name)}
-      />
+        <Chip
+          label={props.name}
+          disabled={!isAdmin}
+          onDelete={() => props.onDelete(props.name)}
+        />
       }
     </div>
   );

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -88,7 +88,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
    */
   const userContext = useContext(Context)
   useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
-  
+
   /**
    * Populate the form when an existing mural is passed as a prop
    */


### PR DESCRIPTION
# Summary

- Changed the multiadd item to a chip
- added name of the prop when we are in "tourist mode" 
<img width="476" alt="Capture d’écran, le 2021-03-30 à 22 30 12" src="https://user-images.githubusercontent.com/48774953/113083236-d8ef6400-91a9-11eb-9d37-5d01697904ab.png">

<img width="152" alt="Capture d’écran, le 2021-03-30 à 22 30 41" src="https://user-images.githubusercontent.com/48774953/113083167-b3625a80-91a9-11eb-9425-2b58b4a28681.png">

- the title for Borough used to display Artist

<img width="168" alt="Capture d’écran, le 2021-03-30 à 14 48 18" src="https://user-images.githubusercontent.com/48774953/113083199-c1b07680-91a9-11eb-949a-f56c443d6658.png">
<img width="178" alt="Capture d’écran, le 2021-03-30 à 14 48 30" src="https://user-images.githubusercontent.com/48774953/113083200-c1b07680-91a9-11eb-99a5-1f5e76747458.png">



## Test Plan

How did you test your changes?

## Related Issues

Which issues does this PR resolve/work on?