### PR TITLE
Fix form width on mobile + general sidebar polish

### DIFF
--- a/frontend/src/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/ActionButtons/ActionButtons.tsx
@@ -10,7 +10,7 @@ import Context from "context";
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     bottomButton: {
-      margin: theme.spacing(0, 0, 0, 3)
+      margin: theme.spacing(0, 0, 0, 2)
     },
     bottomButtonContainer: {
       display: "flex",
@@ -40,39 +40,31 @@ function ActionButtons({ saveCallback, cancelCallback }: IActionButtonsProps) {
   const userContext = useContext(Context)
   useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
 
-  const handleSave = () => {
-    saveCallback()
-  };
-
-  const handleCancel = () => {
-    cancelCallback()
-  };
-
   return (
     <div className={styles.bottomButtonContainer}>
       {
         isAdmin &&
-        <Button
-        color="secondary"
-        size="small"
-        variant="outlined"
-        className={styles.bottomButton}
-        onClick={handleCancel}
-      >
-        Cancel
-        </Button>
-      }
-      {
-        isAdmin &&
-        <Button
-          color="primary"
-          size="small"
-          variant="contained"
-          disableElevation
-          className={styles.bottomButton}
-          onClick={handleSave}>
-          Save
-        </Button>
+        (
+          <div>
+            <Button
+              color="secondary"
+              size="small"
+              className={styles.bottomButton}
+              onClick={cancelCallback}
+            >
+              Cancel
+            </Button>
+            <Button
+              color="primary"
+              size="small"
+              variant="contained"
+              disableElevation
+              className={styles.bottomButton}
+              onClick={saveCallback}>
+              Save
+            </Button>
+          </div>
+        )
       }
     </div>
   )

--- a/frontend/src/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/ActionButtons/ActionButtons.tsx
@@ -16,8 +16,8 @@ const useStyles = makeStyles((theme: Theme) =>
       display: "flex",
       justifyContent: "flex-end",
       padding: theme.spacing(3),
-      width: "40vw",
-      maxWidth: "500px",
+      width: "100%",
+      maxWidth: "100vw",
       bottom: 0
     },
   })

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -105,7 +105,7 @@ function App() {
   };
 
   /**
-   * Zooms the map to the coordiantes of the clicked searched mural
+   * Zooms the map to the coordinates of the clicked searched mural
    * @param long longitude
    * @param lat latitude
    */
@@ -125,8 +125,6 @@ function App() {
     getMural();
     getTour();
   }, []);
-
-  const sidebarTitle = "";
 
   return (
     <div className="App">
@@ -162,7 +160,6 @@ function App() {
           donateClick={() => setDonateOpen(true)}
         />
         <Sidebar
-          name={sidebarTitle}
           isVisible={sidebarOpen}
           closeSidebar={toggleSidebar}
         >

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -114,6 +114,55 @@ function App() {
   };
 
   /**
+   * The mural form supplied with a mural and cancel handler
+   */
+  const muralForm = (
+    <MuralForm mural={selectedResource} handleCancel={toggleSidebar} />
+  );
+
+  /**
+   * The collection form supplied with a collection, all murals,
+   * and handlers for cancellation and mural click
+   */
+  const collectionForm = (
+    <CollectionForm
+      collection={selectedResource}
+      muralsData={murals}
+      handleCancel={toggleSidebar}
+      handleMuralClick={handleSearchedMuralZoom}
+      setSelectedResource={setSelectedResource}
+      setResourceType={setActiveForm}
+    />
+  );
+
+  /**
+   * The tour form supplied with a tour, all murals,
+   * and handlers for cancellation and mural click
+   */
+  const tourForm = (
+    <TourForm
+      tour={selectedResource}
+      muralsData={murals}
+      handleCancel={toggleSidebar}
+      handleMuralClick={handleSearchedMuralZoom}
+      setSelectedResource={setSelectedResource}
+      setResourceType={setActiveForm}
+    />
+  );
+
+  /**
+   * The search component which gets passed into the sidebar
+   */
+  const searchMenu = (
+    <SearchMenu
+      handleMuralClick={handleSearchedMuralZoom}
+      handleCancel={leaveForm}
+      setSelectedResource={setSelectedResource}
+      setResourceType={setActiveForm}
+    />
+  );
+
+  /**
    * When a resource marker is clicked, open its respective form
    */
   useEffect(() => {
@@ -163,27 +212,12 @@ function App() {
           isVisible={sidebarOpen}
           closeSidebar={toggleSidebar}
         >
-          {activeForm === FORM.MURAL ? (
-            <MuralForm mural={selectedResource} handleCancel={toggleSidebar} />
-          ) : activeForm === FORM.COLLECTION ? (
-              <CollectionForm
-                collection={selectedResource}
-                muralsData={murals}
-                handleCancel={toggleSidebar}
-                handleMuralClick={handleSearchedMuralZoom}
-                setSelectedResource={setSelectedResource}
-                setResourceType={setActiveForm}
-              />
-          ) : activeForm === FORM.TOUR ? (
-            <TourForm tour={selectedResource} muralsData={murals} handleCancel={toggleSidebar} />
-          ) : (
-            <SearchMenu
-              handleMuralClick={handleSearchedMuralZoom}
-              handleCancel={leaveForm}
-              setSelectedResource={setSelectedResource}
-              setResourceType={setActiveForm}
-            />
-          )}
+          {
+            activeForm === FORM.MURAL ? muralForm
+            : activeForm === FORM.COLLECTION ? collectionForm
+            : activeForm === FORM.TOUR ? tourForm
+            : searchMenu
+          }
         </Sidebar>
         <LeaveWarning
           open={formWarning}

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -166,17 +166,24 @@ function App() {
           {activeForm === FORM.MURAL ? (
             <MuralForm mural={selectedResource} handleCancel={toggleSidebar} />
           ) : activeForm === FORM.COLLECTION ? (
-            <CollectionForm collection={selectedResource} muralsData={murals} handleCancel={toggleSidebar} />
+              <CollectionForm
+                collection={selectedResource}
+                muralsData={murals}
+                handleCancel={toggleSidebar}
+                handleMuralClick={handleSearchedMuralZoom}
+                setSelectedResource={setSelectedResource}
+                setResourceType={setActiveForm}
+              />
           ) : activeForm === FORM.TOUR ? (
             <TourForm tour={selectedResource} muralsData={murals} handleCancel={toggleSidebar} />
           ) : (
-                  <SearchMenu
-                    handleMuralClick={handleSearchedMuralZoom}
-                    handleCancel={leaveForm}
-                    setSelectedResource={setSelectedResource}
-                    setResourceType={setActiveForm}
-                  />
-                )}
+            <SearchMenu
+              handleMuralClick={handleSearchedMuralZoom}
+              handleCancel={leaveForm}
+              setSelectedResource={setSelectedResource}
+              setResourceType={setActiveForm}
+            />
+          )}
         </Sidebar>
         <LeaveWarning
           open={formWarning}

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme: Theme) =>
       flexDirection: "column",
       alignItems: "start",
       width: "500px",
-      maxWidth: "500px",
+      maxWidth: "100vw",
       padding: theme.spacing(3)
     },
     field: {

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme: Theme) =>
       display: "flex",
       flexDirection: "column",
       alignItems: "start",
-      width: "40vw",
+      width: "500px",
       maxWidth: "500px",
       padding: theme.spacing(3)
     },
@@ -75,7 +75,7 @@ function CollectionForm({ collection, muralsData, handleCancel }: ICollectionFor
   useEffect(() => {
     if (!collection || murals.length === 0) return;
     let temp: any[] = [];
-    collection.murals.forEach((tourMural: any) => {
+    collection.murals?.forEach((tourMural: any) => {
       let found = murals.find((mural: any) => mural.id === tourMural.id);
       temp = ([...temp, found]);
     })

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -12,9 +12,9 @@ import React, { SyntheticEvent, useContext, useEffect, useState } from "react";
 import EditIcon from '@material-ui/icons/Edit';
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import ActionButtons from "../ActionButtons/ActionButtons";
-import SearchCard from "SideBarSearch/searchCard";
+import SearchResultCard from "SearchResultCard/SearchResultCard";
 import Alert from "@material-ui/lab/Alert";
-import { CREATE_MURAL_API, GET_ALL_COLLECTION } from "constants/constants";
+import { CREATE_MURAL_API, FORM, GET_ALL_COLLECTION } from "constants/constants";
 import Context from "context";
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -41,9 +41,12 @@ interface ICollectionFormProps {
   collection?: any;
   muralsData?: any;
   handleCancel: () => void;
+  handleMuralClick: (lat: number, long: number) => void;
+  setSelectedResource: (resource: any) => void;
+  setResourceType: (type: FORM) => void;
 };
 
-function CollectionForm({ collection, muralsData, handleCancel }: ICollectionFormProps) {
+function CollectionForm(props: ICollectionFormProps) {
   const [murals, setMurals] = useState<any>([]);
   const [muralsInCollection, setMuralsInCollection] = useState<any>([]);
   const [muralResults, setMuralResults] = useState<any>([]);
@@ -67,20 +70,20 @@ function CollectionForm({ collection, muralsData, handleCancel }: ICollectionFor
    * Populate the form when an existing collection is passed as a prop
    */
   useEffect(() => {
-    if (!collection || !Object.keys(collection)) return;
-    setTitle(collection.name);
-    setDescription(collection.description);
-  }, [collection])
+    if (!props.collection || !Object.keys(props.collection)) return;
+    setTitle(props.collection.name);
+    setDescription(props.collection.description);
+  }, [props.collection])
 
   useEffect(() => {
-    if (!collection || murals.length === 0) return;
+    if (!props.collection || murals.length === 0) return;
     let temp: any[] = [];
-    collection.murals?.forEach((tourMural: any) => {
+    props.collection.murals?.forEach((tourMural: any) => {
       let found = murals.find((mural: any) => mural.id === tourMural.id);
       temp = ([...temp, found]);
     })
     setMuralsInCollection(temp);
-  }, [collection, murals]);
+  }, [props.collection, murals]);
 
   /**
    * Enable editable form fields for admin users
@@ -142,7 +145,7 @@ function CollectionForm({ collection, muralsData, handleCancel }: ICollectionFor
           <InputBase
             className={`${styles.title} ${styles.field}`}
             placeholder="Name the collection"
-            defaultValue={collection?.name}
+            defaultValue={props.collection?.name}
             disabled={!isAdmin}
             onChange={(e: any) => setTitle(e.target.value)}
             inputProps={{ 'aria-label': 'New collection title' }}
@@ -161,7 +164,7 @@ function CollectionForm({ collection, muralsData, handleCancel }: ICollectionFor
             multiline
             rows={4}
             placeholder="Add a description"
-            defaultValue={collection?.description}
+            defaultValue={props.collection?.description}
             disabled={!isAdmin}
             onChange={(e: any) => setDescription(e.target.value)}
             onClick={() => setEditingDesc(true)}
@@ -198,8 +201,24 @@ function CollectionForm({ collection, muralsData, handleCancel }: ICollectionFor
           </div>
         </div>
       </form>
-      <SearchCard searchCards={muralsInCollection} />
-      <ActionButtons saveCallback={handleSave} cancelCallback={handleCancel} />
+      <div className={styles.flexContainer}>
+        {muralsInCollection.map((mural: any) => {
+          return (
+            <SearchResultCard
+              type={FORM.MURAL}
+              item={mural}
+              key={mural.id}
+              handleMuralClick={props.handleMuralClick}
+              handleCancel={props.handleCancel}
+              setSelectedResource={props.setSelectedResource}
+              setResourceType={props.setResourceType}
+            />
+          )
+        })}
+      </div>
+      <ActionButtons
+        saveCallback={handleSave}
+        cancelCallback={props.handleCancel} />
       <Snackbar open={popup} autoHideDuration={6000}>
         <Alert severity="success">
           Collection published successfully!

--- a/frontend/src/ImageUpload/ImageUpload.tsx
+++ b/frontend/src/ImageUpload/ImageUpload.tsx
@@ -9,6 +9,7 @@ import { FirebaseStorage } from "../firebase/index";
 import "firebase/storage";
 import firebase from "firebase/app";
 import HighlightOffOutlinedIcon from "@material-ui/icons/HighlightOffOutlined";
+import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import Context from "context";
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -20,29 +21,30 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
       flexDirection: "row",
       width: '100%',
-      flexWrap: "wrap"
+      flexWrap: "wrap",
+      justifyContent: "space-between"
     },
     imageCard: {
       display: 'flex',
-      width: '45%',
+      width: '48%',
       height: "30%",
       flexDirection: "row-reverse",
       position: 'relative',
-      margin: "0 auto",
-      padding: "5px"
+      padding: theme.spacing(1, 0, 1, 0)
     },
     uploadButton: {
-      width: '100%',
-      margin: '15px auto'
+      margin: theme.spacing(1, 0, 1, 0),
     },
     muralImage: {
       borderRadius: '10px',
       width: '100%',
-      height: '120px'
+      height: '120px',
+      objectFit: 'cover'
     },
     deleteButton: {
       position: 'absolute',
-      padding: theme.spacing(1)
+      padding: theme.spacing(1),
+      margin: theme.spacing(-2, -2, 0, 0)
     }
   })
 );
@@ -129,46 +131,59 @@ function ImageUpload({
   function dummyImage(imgsUrlAndPath: Image[]) {
     if (imgsUrlAndPath.length % 2 === 1) {
       return (
-        <div className={styles.imageCard}>
-        </div>
+        <div className={styles.imageCard} />
       )
     }
   }
+
+  /**
+   * Loop over the mural's images and create image components
+   * If the user is an admin, show a remove button
+   */
+  const uploadedImages = imgsUrlAndPath.map(
+    (urlAndPath: any) => {
+      return (
+        <div
+          className={styles.imageCard}
+          key={urlAndPath.url + "_"}
+        >
+          <img
+            alt="mural"
+            className={styles.muralImage}
+            key={urlAndPath.url}
+            src={urlAndPath.url}
+            />
+          {
+            isAdmin &&
+            <IconButton
+              onClick={() => handleRemove(urlAndPath.path)}
+              className={styles.deleteButton}
+            >
+              <HighlightOffOutlinedIcon color="secondary" />
+            </IconButton>
+          }
+        </div>
+      );
+    }
+  );
 
   return (
     <div className={styles.root}>
       {
         isAdmin &&
-        <Button variant="contained" component="label" className={styles.uploadButton}>
+        <Button
+          variant="outlined"
+          component="label"
+          disableElevation
+          className={styles.uploadButton}
+          startIcon={<CloudUploadIcon />}
+        >
           Upload Mural Picture
           <input type="file" hidden onChange={handleUpload} accept="image/*" />
         </Button>
       }
       <div className={styles.imageContainer}>
-        {imgsUrlAndPath.map((urlAndPath) => {
-          return (
-            <div
-              className={styles.imageCard}
-              key={urlAndPath.url + "_"}
-            >
-            {
-              isAdmin &&
-              <IconButton
-                onClick={() => handleRemove(urlAndPath.path)}
-                className={styles.deleteButton}
-                >
-                <HighlightOffOutlinedIcon color="secondary" />
-              </IconButton>
-              }
-              <img
-                alt="mural"
-                className={styles.muralImage}
-                key={urlAndPath.url}
-                src={urlAndPath.url}
-              />
-            </div>
-          );
-        })}
+        {uploadedImages}
         {dummyImage(imgsUrlAndPath)}
       </div>
     </div>

--- a/frontend/src/ImageUpload/ImageUpload.tsx
+++ b/frontend/src/ImageUpload/ImageUpload.tsx
@@ -8,8 +8,8 @@ import {
 import { FirebaseStorage } from "../firebase/index";
 import "firebase/storage";
 import firebase from "firebase/app";
-import HighlightOffOutlinedIcon from "@material-ui/icons/HighlightOffOutlined";
-import CloudUploadIcon from '@material-ui/icons/CloudUpload';
+import ClearIcon from "@material-ui/icons/Clear";
+import PublishIcon from '@material-ui/icons/Publish';
 import Context from "context";
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -22,7 +22,8 @@ const useStyles = makeStyles((theme: Theme) =>
       flexDirection: "row",
       width: '100%',
       flexWrap: "wrap",
-      justifyContent: "space-between"
+      justifyContent: "space-between",
+      marginBottom: theme.spacing(3)
     },
     imageCard: {
       display: 'flex',
@@ -34,17 +35,18 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     uploadButton: {
       margin: theme.spacing(1, 0, 1, 0),
+      width:"48%"
     },
     muralImage: {
-      borderRadius: '10px',
+      borderRadius: '4px',
       width: '100%',
       height: '120px',
       objectFit: 'cover'
     },
     deleteButton: {
       position: 'absolute',
-      padding: theme.spacing(1),
-      margin: theme.spacing(-2, -2, 0, 0)
+      margin: theme.spacing(1, 1, 0, 0),
+      backgroundColor: "#00000080"
     }
   })
 );
@@ -156,10 +158,11 @@ function ImageUpload({
           {
             isAdmin &&
             <IconButton
+              size="small"
               onClick={() => handleRemove(urlAndPath.path)}
               className={styles.deleteButton}
             >
-              <HighlightOffOutlinedIcon color="secondary" />
+              <ClearIcon style={{color:"#fff"}} />
             </IconButton>
           }
         </div>
@@ -168,24 +171,22 @@ function ImageUpload({
   );
 
   return (
-    <div className={styles.root}>
+    <div className={styles.imageContainer}>
       {
         isAdmin &&
         <Button
-          variant="outlined"
+          variant="contained"
           component="label"
           disableElevation
           className={styles.uploadButton}
-          startIcon={<CloudUploadIcon />}
+          startIcon={<PublishIcon />}
         >
-          Upload Mural Picture
+          Upload Image
           <input type="file" hidden onChange={handleUpload} accept="image/*" />
         </Button>
       }
-      <div className={styles.imageContainer}>
-        {uploadedImages}
-        {dummyImage(imgsUrlAndPath)}
-      </div>
+      {uploadedImages}
+      {dummyImage(imgsUrlAndPath)}
     </div>
   );
 }

--- a/frontend/src/SearchMenu/SearchMenu.tsx
+++ b/frontend/src/SearchMenu/SearchMenu.tsx
@@ -15,7 +15,8 @@ const useStyles = makeStyles((theme: Theme) =>
       display: "flex",
       flexDirection: "column",
       alignItems: "flexStart",
-      maxWidth: "500px",
+      width: "500px",
+      maxWidth: "100vw",
       padding: theme.spacing(3),
     },
     field: {
@@ -36,6 +37,7 @@ const useStyles = makeStyles((theme: Theme) =>
     noResults: {
       textAlign: "center",
       fontSize: "170%",
+      color: "grey"
     },
   })
 );
@@ -126,7 +128,7 @@ function SearchMenu(props: ISearchMenuProps) {
         {displayedCollections.length < 1 &&
           displayedMurals.length < 1 &&
           displayedTours.length < 1 && (
-            <p className={styles.noResults}>No Results</p>
+            <p className={styles.noResults}>Keep searching</p>
           )}
         {displayedMurals.map((mural: any) => {
           return (

--- a/frontend/src/SearchResultCard/SearchResultCard.tsx
+++ b/frontend/src/SearchResultCard/SearchResultCard.tsx
@@ -2,31 +2,35 @@ import Card from "@material-ui/core/Card";
 import Typography from "@material-ui/core/Typography";
 import { createStyles, makeStyles, Theme } from "@material-ui/core";
 import React from "react";
-import { FORM } from "constants/constants";
+import { FORM, PLACEHOLDER_IMAGE } from "constants/constants";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     card: {
-      margin: theme.spacing(0, 2, 2, 3),
+      marginBottom: theme.spacing(2),
       display: "flex",
-      justifyContent: "flex-start",
-      width: "90%",
-      cursor: "pointer"
+      width: "100%",
+      maxHeight: "80px",
+      cursor: "pointer",
+      boxShadow: "0px 0px 20px 0px #99999940"
     },
     icon: {
-      maxWidth: "25%",
-      height: "100%",
+      width: "25%",
+      minHeight: "100%",
+      objectFit: "cover"
     },
     properties: {
       display: "flex",
       flexDirection: "column",
-      justifyContent: "space-between",
-      padding: theme.spacing(0, 0, 1, 2),
-      width: "50%",
+      flexGrow: 1,
+      justifyContent: "space-around",
+      margin: theme.spacing(1, 2, 1, 2),
+      width: "75%",
     },
-    type: {
-      margin: theme.spacing(1, 0, 0, 1),
-      color: theme.palette.error.main,
+    title: {
+      display: "flex",
+      flexDirection: "row",
+      justifyContent: "space-between",
     },
   })
 );
@@ -81,16 +85,20 @@ function SearchResultCard(props: ISearchCardSetProps) {
     <Card className={styles.card} onClick={handleClick}>
       <img
         className={styles.icon}
-        src="https://cdn2.lamag.com/wp-content/uploads/sites/6/2020/01/kobe-mural-mr-brainwash-chris-delmas-afp-getty-1068x712.jpg"
+        src={props.item.imgURLs ? props.item.imgURLs[0] : PLACEHOLDER_IMAGE}
         alt="mural"
-      ></img>
+      />
       <div className={styles.properties}>
-        <Typography variant="subtitle1">{props.item.name}</Typography>
-        <Typography variant="body2">{body}</Typography>
+        <div className={styles.title}>
+          <Typography variant="body2">
+            <strong>{props.item.name}</strong>
+          </Typography>
+          <Typography variant="overline" color="error">
+            {props.type}
+          </Typography>
+        </div>
+        <Typography variant="caption">{body}</Typography>
       </div>
-      <Typography variant="body1" className={styles.type}>
-        {props.type}
-      </Typography>
     </Card>
   );
 }

--- a/frontend/src/TourForm/TourForm.tsx
+++ b/frontend/src/TourForm/TourForm.tsx
@@ -24,8 +24,8 @@ const useStyles = makeStyles((theme: Theme) =>
       display: "flex",
       flexDirection: "column",
       alignItems: "start",
-      width: "40vw",
-      maxWidth: "500px",
+      width: "500px",
+      maxWidth: "100vw",
       padding: theme.spacing(3),
       paddingBottom: theme.spacing(0),
     },
@@ -81,7 +81,7 @@ function TourForm({ tour, muralsData, handleCancel }: ITourFormProps) {
   useEffect(() => {
     if (!tour || murals.length === 0) return;
     let temp: any[] = [];
-    tour.murals.forEach((tourMural: any) => {
+    tour.murals?.forEach((tourMural: any) => {
       let found = murals.find((mural: any) => mural.id === tourMural.id);
       temp = ([...temp, found]);
     })

--- a/frontend/src/TourForm/TourForm.tsx
+++ b/frontend/src/TourForm/TourForm.tsx
@@ -14,9 +14,9 @@ import Autocomplete from "@material-ui/lab/Autocomplete";
 import ActionButtons from "../ActionButtons/ActionButtons";
 import DragDrop from "DragDrop/DragDrop";
 import Alert from "@material-ui/lab/Alert";
-import { CREATE_MURAL_API, GET_ALL_TOUR } from "constants/constants";
+import { CREATE_MURAL_API, FORM, GET_ALL_TOUR } from "constants/constants";
 import Context from "context";
-import SearchCard from "SideBarSearch/searchCard";
+import SearchResultCard from "SearchResultCard/SearchResultCard";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -47,9 +47,12 @@ interface ITourFormProps {
   tour?: any;
   muralsData?: any;
   handleCancel: () => void;
+  handleMuralClick: (lat: number, long: number) => void;
+  setSelectedResource: (resource: any) => void;
+  setResourceType: (type: FORM) => void;
 }
 
-function TourForm({ tour, muralsData, handleCancel }: ITourFormProps) {
+function TourForm(props: ITourFormProps) {
   const [murals, setMurals] = useState<any>([]);
   const [muralsInTour, setMuralsInTour] = useState<any>([]);
   const [muralResults, setMuralResults] = useState<any>([]);
@@ -73,20 +76,20 @@ function TourForm({ tour, muralsData, handleCancel }: ITourFormProps) {
    * Populate the form when an existing tour is passed as a prop
    */
    useEffect(() => {
-    if (!tour || !Object.keys(tour)) return;
-    setTitle(tour.name);
-    setDescription(tour.description);
-  }, [tour])
+    if (!props.tour || !Object.keys(props.tour)) return;
+    setTitle(props.tour.name);
+    setDescription(props.tour.description);
+  }, [props.tour])
 
   useEffect(() => {
-    if (!tour || murals.length === 0) return;
+    if (!props.tour || murals.length === 0) return;
     let temp: any[] = [];
-    tour.murals?.forEach((tourMural: any) => {
+    props.tour.murals?.forEach((tourMural: any) => {
       let found = murals.find((mural: any) => mural.id === tourMural.id);
       temp = ([...temp, found]);
     })
     setMuralsInTour(temp);
-  }, [tour, murals])
+  }, [props.tour, murals])
 
   /**
    * Enable editable form fields for admin users
@@ -158,7 +161,7 @@ function TourForm({ tour, muralsData, handleCancel }: ITourFormProps) {
     } else {
       setMuralResults(murals);
     }
-  }, [muralQuery, murals, muralsData]);
+  }, [muralQuery, murals, props.muralsData]);
 
   return (
     <div>
@@ -174,7 +177,7 @@ function TourForm({ tour, muralsData, handleCancel }: ITourFormProps) {
           <InputBase
             className={`${styles.title} ${styles.field}`}
             placeholder="Name the tour"
-            defaultValue={tour?.name}
+            defaultValue={props.tour?.name}
             disabled={!isAdmin}
             onChange={(e: any) => setTitle(e.target.value)}
             inputProps={{ "aria-label": "New tour title" }}
@@ -195,7 +198,7 @@ function TourForm({ tour, muralsData, handleCancel }: ITourFormProps) {
             multiline
             rows={4}
             placeholder="Add a description"
-            defaultValue={tour?.description}
+            defaultValue={props.tour?.description}
             disabled={!isAdmin}
             onChange={(e: any) => setDescription(e.target.value)}
             onClick={() => setEditingDesc(true)}
@@ -249,10 +252,27 @@ function TourForm({ tour, muralsData, handleCancel }: ITourFormProps) {
             itemDeletedCallback={removeMural}
           />
         ) : (
-          <SearchCard searchCards={muralsInTour} />
+          <div className={styles.flexContainer}>
+            {muralsInTour.map((mural: any) => {
+              return (
+                <SearchResultCard
+                  type={FORM.MURAL}
+                  item={mural}
+                  key={mural.id}
+                  handleMuralClick={props.handleMuralClick}
+                  handleCancel={props.handleCancel}
+                  setSelectedResource={props.setSelectedResource}
+                  setResourceType={props.setResourceType}
+                />
+              )
+            })}
+          </div>
         )
       }
-      <ActionButtons saveCallback={handleSave} cancelCallback={handleCancel} />
+      <ActionButtons
+        saveCallback={handleSave}
+        cancelCallback={props.handleCancel}
+      />
       <Snackbar open={popup} autoHideDuration={6000}>
         <Alert severity="success">Tour published successfully!</Alert>
       </Snackbar>

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -50,7 +50,6 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     directionButton: {
       width: "100%",
-      marginTop: theme.spacing(2)
     },
   })
 );

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -50,7 +50,8 @@ const useStyles = makeStyles((theme: Theme) =>
       fontSize: "180%",
     },
     directionButton: {
-      width: "100%"
+      width: "100%",
+      marginTop: theme.spacing(2)
     },
   })
 );

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -11,7 +11,6 @@ import AddressSearch from "../AddressSearch/addressSearch";
 import MultiAdd from "../multiAdd/MultiAdd";
 import ActionButtons from "../ActionButtons/ActionButtons";
 import EditIcon from "@material-ui/icons/Edit";
-import DirectionsIcon from '@material-ui/icons/Directions';
 import axios from "axios";
 import {
   CREATE_MURAL_API,
@@ -364,7 +363,6 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             disableElevation
             className={styles.directionButton}
             onClick={() => setDirectionOpen(true)}
-            startIcon={<DirectionsIcon />}
           >
             Directions
           </Button>

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -11,6 +11,7 @@ import AddressSearch from "../AddressSearch/addressSearch";
 import MultiAdd from "../multiAdd/MultiAdd";
 import ActionButtons from "../ActionButtons/ActionButtons";
 import EditIcon from "@material-ui/icons/Edit";
+import DirectionsIcon from '@material-ui/icons/Directions';
 import axios from "axios";
 import {
   CREATE_MURAL_API,
@@ -49,8 +50,7 @@ const useStyles = makeStyles((theme: Theme) =>
       fontSize: "180%",
     },
     directionButton: {
-      display: "block",
-      margin: "0 auto",
+      width: "100%"
     },
   })
 );
@@ -356,6 +356,17 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             removeHandler={handleImgUrlRemove}
             imgsUrlAndPath={imgUrlsAndPath}
           />
+          <Button
+            color="primary"
+            size="medium"
+            variant="outlined"
+            disableElevation
+            className={styles.directionButton}
+            onClick={() => setDirectionOpen(true)}
+            startIcon={<DirectionsIcon />}
+          >
+            Get Directions
+          </Button>
         </div>
       </form>
       <Directions
@@ -364,21 +375,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
         coordinates={[currentPos, addressCoords]}
         wpNames={[name]}
         wpPics={imgUrlsAndPath[0] ? [imgUrlsAndPath[0].url] : [""]} // use the first image to display
-      ></Directions>
-
-      <div>
-        <Button
-          color="primary"
-          size="medium"
-          variant="contained"
-          disableElevation
-          className={styles.directionButton}
-          onClick={() => setDirectionOpen(true)}
-        >
-          Direction
-        </Button>
-      </div>
-
+      />
       <ActionButtons saveCallback={submitForm} cancelCallback={handleCancel} />
       <Snackbar open={popup} autoHideDuration={6000}>
         <Alert severity="success">Mural published successfully!</Alert>

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -366,7 +366,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             onClick={() => setDirectionOpen(true)}
             startIcon={<DirectionsIcon />}
           >
-            Get Directions
+            Directions
           </Button>
         </div>
       </form>

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -23,8 +23,8 @@ const useStyles = makeStyles((theme: Theme) =>
       display: "flex",
       flexDirection: "column",
       alignItems: "start",
-      width: "40vw",
-      maxWidth: "500px",
+      width: "500px",
+      maxWidth: "100vw",
       padding: theme.spacing(3),
     },
     element: {
@@ -282,7 +282,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             callback={(artistId: number | null) => setArtist(artistId)}
             endpoint={GET_ALL_ARTISTS_API}
             label="Artist"
-            placeHolder="Who made it"
+            placeHolder="Who made it?"
           />
           <ArtistBoroughSearch
             defaultSelection={mural?.boroughId}

--- a/frontend/src/sidebar/Sidebar.tsx
+++ b/frontend/src/sidebar/Sidebar.tsx
@@ -30,7 +30,6 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 interface ISidebarProps {
-  name: string;
   children?: React.ReactNode | null;
   isVisible: boolean;
   closeSidebar: () => void;
@@ -52,7 +51,6 @@ function Sidebar(props: ISidebarProps) {
             className={styles.closeIcon}
           />
         </div>
-        <p className={styles.title}>{props.name}</p>
         <div className={styles.flexContainer}>{props.children}</div>
       </Drawer>
     </div>

--- a/frontend/src/sidebar/Sidebar.tsx
+++ b/frontend/src/sidebar/Sidebar.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme: Theme) =>
     closeIcon: {
       cursor: "pointer",
       float: "right",
-      margin: theme.spacing(2),
+      margin: theme.spacing(2, 2, 0, 0),
     },
     flexContainer: {
       display: "flex",

--- a/frontend/src/sidebar/Sidebar.tsx
+++ b/frontend/src/sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Drawer from "@material-ui/core/Drawer";
 import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 import CloseIcon from "@material-ui/icons/Close";
+import IconButton from "@material-ui/core/IconButton";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -9,17 +10,10 @@ const useStyles = makeStyles((theme: Theme) =>
       paper: "primary",
       width: "30%",
     },
-    title: {
-      fontSize: "180%",
-      fontWeight: 500,
-      paddingLeft: theme.spacing(3),
-      paddingRight: theme.spacing(25),
-    },
     closeIcon: {
       cursor: "pointer",
       float: "right",
-      marginTop: theme.spacing(2),
-      marginRight: theme.spacing(3),
+      margin: theme.spacing(2),
     },
     flexContainer: {
       display: "flex",
@@ -45,12 +39,13 @@ function Sidebar(props: ISidebarProps) {
         open={props.isVisible}
         onClose={props.closeSidebar}
       >
-        <div>
-          <CloseIcon
+        <span>
+          <IconButton
             onClick={props.closeSidebar}
-            className={styles.closeIcon}
-          />
-        </div>
+            className={styles.closeIcon}>
+            <CloseIcon />
+          </IconButton>
+        </span>
         <div className={styles.flexContainer}>{props.children}</div>
       </Drawer>
     </div>


### PR DESCRIPTION
# Summary

- Fix form width on mobile
- Fix bug where the tour and collection forms would crash when opened after opening a mural
- Adjust image upload appearance and spacing
- Simplify ActionButtons (save and cancel) code
- Make Sidebar close icon into button
- Polish SearchResultCard
- Remove duplicate searchCard component

## Test Plan

Form on mobile, signed out:
<img width="300" alt="Screen Shot 2021-04-01 at 3 12 24 PM" src="https://user-images.githubusercontent.com/36117635/113342596-abff9600-92fc-11eb-9194-1bfe03da79eb.png">

Image upload:
<img width="400" src="https://user-images.githubusercontent.com/36117635/113342684-c46fb080-92fc-11eb-8994-f97f02da071e.png" />

Search results:
<img width="400" alt="Screen Shot 2021-04-01 at 4 39 16 PM" src="https://user-images.githubusercontent.com/36117635/113351394-d0616f80-9308-11eb-9c5f-42285e098736.png">

Collection form:
<img width="400" src="https://user-images.githubusercontent.com/36117635/113353351-8332cd00-930b-11eb-97ef-91572f9805dc.png" />


## Related Issues

Closes #157 
