### PR TITLE
Fix directions

### DIFF
--- a/frontend/src/Directions/Directions.tsx
+++ b/frontend/src/Directions/Directions.tsx
@@ -69,42 +69,34 @@ function Directions(props: IDirectionsProps) {
   const [waypoints, setWaypoints] = useState<any[]>([]);
 
   useEffect(() => {
-    if (props.open) {
-      let coordString = "";
-      for (let i = 0; i < props.coordinates.length; i++) {
-        coordString += props.coordinates[i][0];
-        coordString += ",";
-        coordString += props.coordinates[i][1];
-        if (i !== props.coordinates.length - 1) coordString += ";";
-      }
-      var url =
-        MAPBOX_DIRECTIONS_API +
-        coordString +
-        "?steps=true&geometries=geojson&access_token=" +
-        process.env.REACT_APP_MAPBOX_TOKEN;
-      axios
-        .get(url)
-        .then((res) => {
-          let timeRequired = new Date(res.data.routes[0].duration * 1000)
-            .toISOString()
-            .substr(11, 8);
-          // Converts "hh:mm:ss" to an array of int type, [hh, mm, ss]
-          setTimeRequired(
-            timeRequired.split(":").map((time) => parseInt(time))
-          );
-          setTotalDistance(Math.round(res.data.routes[0].distance / 1000)); // m -> km
-
-          var zip = props.wpNames.map((n, i) => [
-            n,
-            res.data.routes[0].legs[i],
-          ]);
-          setWaypoints(zip);
-        })
-        .catch(() => {
-          // Unable to get directions from MapBox API
-        });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (!props.open) return;
+    let coordString = "";
+    for (let i = 0; i < props.coordinates.length; i++) {
+      coordString += props.coordinates[i][0];
+      coordString += ",";
+      coordString += props.coordinates[i][1];
+      if (i !== props.coordinates.length - 1) coordString += ";";
     }
+    var url =
+      MAPBOX_DIRECTIONS_API +
+      coordString +
+      "?steps=true&geometries=geojson&access_token=" +
+      process.env.REACT_APP_MAPBOX_TOKEN;
+    axios
+      .get(url)
+      .then((res) => {
+        let timeRequired = new Date(res.data.routes[0].duration * 1000)
+          .toISOString()
+          .substr(11, 8);
+        // Converts "hh:mm:ss" to an array of int type, [hh, mm, ss]
+        setTimeRequired(timeRequired.split(":").map((time) => parseInt(time)));
+        setTotalDistance(Math.round(res.data.routes[0].distance / 1000)); // m -> km
+
+        var zip = props.wpNames.map((n, i) => [n, res.data.routes[0].legs[i]]);
+        setWaypoints(zip);
+      })
+      .catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.coordinates, props.wpNames, props.open]);
 
   function timingText(timeRequired: number[]) {

--- a/frontend/src/Directions/Directions.tsx
+++ b/frontend/src/Directions/Directions.tsx
@@ -69,38 +69,43 @@ function Directions(props: IDirectionsProps) {
   const [waypoints, setWaypoints] = useState<any[]>([]);
 
   useEffect(() => {
-    console.log(props.coordinates);
-    let coordString = "";
-    for (let i = 0; i < props.coordinates.length; i++) {
-      coordString += props.coordinates[i][0];
-      coordString += ",";
-      coordString += props.coordinates[i][1];
-      if (i !== props.coordinates.length - 1) coordString += ";";
-    }
-    var url =
-      MAPBOX_DIRECTIONS_API +
-      coordString +
-      "?steps=true&geometries=geojson&access_token=" +
-      process.env.REACT_APP_MAPBOX_TOKEN;
-    axios
-      .get(url)
-      .then((res) => {
-        let timeRequired = new Date(res.data.routes[0].duration * 1000)
-          .toISOString()
-          .substr(11, 8);
-        // Converts "hh:mm:ss" to an array of int type, [hh, mm, ss]
-        setTimeRequired(timeRequired.split(":").map((time) => parseInt(time)));
-        setTotalDistance(Math.round(res.data.routes[0].distance / 1000)); // m -> km
+    if (props.open) {
+      let coordString = "";
+      for (let i = 0; i < props.coordinates.length; i++) {
+        coordString += props.coordinates[i][0];
+        coordString += ",";
+        coordString += props.coordinates[i][1];
+        if (i !== props.coordinates.length - 1) coordString += ";";
+      }
+      var url =
+        MAPBOX_DIRECTIONS_API +
+        coordString +
+        "?steps=true&geometries=geojson&access_token=" +
+        process.env.REACT_APP_MAPBOX_TOKEN;
+      axios
+        .get(url)
+        .then((res) => {
+          let timeRequired = new Date(res.data.routes[0].duration * 1000)
+            .toISOString()
+            .substr(11, 8);
+          // Converts "hh:mm:ss" to an array of int type, [hh, mm, ss]
+          setTimeRequired(
+            timeRequired.split(":").map((time) => parseInt(time))
+          );
+          setTotalDistance(Math.round(res.data.routes[0].distance / 1000)); // m -> km
 
-        var zip = props.wpNames.map((n, i) => [n, res.data.routes[0].legs[i]]);
-        setWaypoints(zip);
-        console.log(zip);
-      })
-      .catch(() => {
-        console.log("error");
-      });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+          var zip = props.wpNames.map((n, i) => [
+            n,
+            res.data.routes[0].legs[i],
+          ]);
+          setWaypoints(zip);
+        })
+        .catch(() => {
+          // Unable to get directions from MapBox API
+        });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }
+  }, [props.coordinates, props.wpNames, props.open]);
 
   function timingText(timeRequired: number[]) {
     if (timeRequired[2] > 30) {

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -91,13 +91,14 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
   const [directionOpen, setDirectionOpen] = useState<boolean>(false);
 
   const [currentPos, setCurrentPos] = useState<number[]>([]);
+  const [isGeoOn, setIsGeoOn] = useState<boolean>(false);
 
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
   /**
    * Enable editable form fields for admin users
    */
-  const userContext: any = useContext(Context)
+  const userContext: any = useContext(Context);
   useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
 
   /**
@@ -127,10 +128,12 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
 
   function success(pos: any) {
     setCurrentPos([pos.coords.longitude, pos.coords.latitude]);
+    setIsGeoOn(true);
   }
 
   function error(err: any) {
     console.warn(`ERROR(${err.code}): ${err.message}`);
+    setIsGeoOn(false);
   }
 
   useEffect(() => {
@@ -187,26 +190,26 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
      * we either update or add a new mural.
      */
     axios({
-      method: existingMural ? 'put' : 'post',
-      url: existingMural ?
-        `${CREATE_MURAL_API}/${payload.id}` : CREATE_MURAL_API,
+      method: existingMural ? "put" : "post",
+      url: existingMural
+        ? `${CREATE_MURAL_API}/${payload.id}`
+        : CREATE_MURAL_API,
       data: payload,
-      headers:  {
-          authorization: userContext.token.i
-        }
-    })
-      .then(
-        (response) => {
-          console.log(response);
-          setPopup(true);
-          let context = userContext as any;
-          context.getMural();
-          setTimeout(() => setPopup(false), 5000);
-        },
-        (error) => {
-          console.log(error);
-        }
-      );
+      headers: {
+        authorization: userContext.token.i,
+      },
+    }).then(
+      (response) => {
+        console.log(response);
+        setPopup(true);
+        let context = userContext as any;
+        context.getMural();
+        setTimeout(() => setPopup(false), 5000);
+      },
+      (error) => {
+        console.log(error);
+      }
+    );
   }
 
   function handleAddressUpdate(
@@ -248,6 +251,24 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
     path = path.replaceAll("%20", " ");
     path = path.replaceAll("%2F", "/");
     return path;
+  }
+
+  function directionsButton() {
+    if (isGeoOn) {
+      return (
+        <Button
+          color="primary"
+          size="medium"
+          variant="outlined"
+          disableElevation
+          className={styles.directionButton}
+          onClick={() => setDirectionOpen(true)}
+        >
+          Directions
+        </Button>
+      );
+    }
+    return null;
   }
 
   return (
@@ -357,16 +378,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
             removeHandler={handleImgUrlRemove}
             imgsUrlAndPath={imgUrlsAndPath}
           />
-          <Button
-            color="primary"
-            size="medium"
-            variant="outlined"
-            disableElevation
-            className={styles.directionButton}
-            onClick={() => setDirectionOpen(true)}
-          >
-            Directions
-          </Button>
+          {directionsButton()}
         </div>
       </form>
       <Directions


### PR DESCRIPTION
# Summary

- Removed console logs from the Directions PR

Getting rid of MapBox API calls on undefined coords:
- Fixed useEffect in Directions so that the API call is only done when the directions page is opened 
- Render the directions button on the mural form only when geolocation is available (could maybe be made un/clickable instead)

## Test Plan

test in browser using dev tools

## Related Issues
 
-