### PR TITLE
Add Vercel banner for open-source sponsorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ Toolbox instead of Docker Desktop, type `docker-machine ip` into your command li
 🚀 The client-side and server code both deploy automatically when a PR is merged into [`main`](https://github.com/hack4impact-mcgill/mu-map).
 - The frontend is deployed and hosted by [Vercel](https://vercel.com/).
 - The backend is deployed via our [CD script](https://github.com/hack4impact-mcgill/mu-map/blob/main/.github/workflows/deploy_backend.yml), which generates a [build](https://create-react-app.dev/docs/production-build/), [zip](https://en.wikipedia.org/wiki/ZIP_(file_format))s it, then deploys the artifact to our AWS Elastic Beanstalk (EB). The backend runs on an AWS EC2 instance (which is just a Linux VM). That EC2 is wrapped by an AWS Elastic Load Balancer (ELB) to receive and downgrade incoming HTTPS traffic to HTTP. The ELB's IP address is stored as the [A record](https://support.dnsimple.com/articles/a-record/) of **[api.mumap.xyz](https://api.mumap.xyz/artist)** in Vercel.
+
+<img src="https://www.datocms-assets.com/31049/1618983297-powered-by-vercel.svg">

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ Toolbox instead of Docker Desktop, type `docker-machine ip` into your command li
 - The frontend is deployed and hosted by [Vercel](https://vercel.com/).
 - The backend is deployed via our [CD script](https://github.com/hack4impact-mcgill/mu-map/blob/main/.github/workflows/deploy_backend.yml), which generates a [build](https://create-react-app.dev/docs/production-build/), [zip](https://en.wikipedia.org/wiki/ZIP_(file_format))s it, then deploys the artifact to our AWS Elastic Beanstalk (EB). The backend runs on an AWS EC2 instance (which is just a Linux VM). That EC2 is wrapped by an AWS Elastic Load Balancer (ELB) to receive and downgrade incoming HTTPS traffic to HTTP. The ELB's IP address is stored as the [A record](https://support.dnsimple.com/articles/a-record/) of **[api.mumap.xyz](https://api.mumap.xyz/artist)** in Vercel.
 
-<img src="https://www.datocms-assets.com/31049/1618983297-powered-by-vercel.svg">
+[<img src="https://www.datocms-assets.com/31049/1618983297-powered-by-vercel.svg">](https://vercel.com?utm_source=mumap&utm_campaign=oss)

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -17,7 +17,7 @@ import SearchMenu from "SearchMenu/SearchMenu";
 import SearchButton from "SearchButton/SearchButton";
 import DonationModal from "DonationModal/DonationModal";
 import WelcomeModal from "WelcomeModal/WelcomeModal";
-
+import VercelLogo from "components/VercelLogo";
 
 function App() {
   const [isSignedIn, setIsSignedIn] = useState<boolean>(false);
@@ -51,7 +51,7 @@ function App() {
       .then(() => {
         setSigningIn(false);
         setSignInError("");
-        setJWTtoken(FirebaseAuth.currentUser?.getIdToken(true))
+        setJWTtoken(FirebaseAuth.currentUser?.getIdToken(true));
       })
       .catch((error: any) => {
         console.log(error.message);
@@ -203,7 +203,7 @@ function App() {
 
   return (
     <div className="App">
-      <Context.Provider value={{ user: user, token : JWTtoken, getMural }}>
+      <Context.Provider value={{ user: user, token: JWTtoken, getMural }}>
         <SigninForm
           signInClick={handleSignin}
           cancelClick={() => setSigningIn(false)}
@@ -251,6 +251,7 @@ function App() {
           handleLeave={leaveForm}
         />
         <PlusButton isVisible={isSignedIn} handleClick={toggleSidebar} />
+        <VercelLogo />
       </Context.Provider>
     </div>
   );

--- a/frontend/src/components/VercelLogo.tsx
+++ b/frontend/src/components/VercelLogo.tsx
@@ -1,0 +1,43 @@
+import { Button, makeStyles, Theme } from "@material-ui/core";
+import React from "react";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  button: {
+    position: "sticky",
+    bottom: theme.spacing(0.5),
+    width: 120,
+    margin: "auto",
+    textTransform: "none",
+  },
+}));
+
+const VercelLogo = () => {
+  const { button } = useStyles();
+
+  return (
+    <Button
+      className={button}
+      size="small"
+      href="https://vercel.com?utm_source=mumap&utm_campaign=oss"
+      target="_blank"
+    >
+      Powered by
+      <svg
+        width="30px"
+        height="30px"
+        viewBox="97 80 100 82"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <title>Vercel Unicode Light</title>
+        <path
+          d="M159.772 108.37h22.475l-11.242-18.545-11.233 18.545z"
+          fill="black"
+          transform="scale(3.5) translate(-130, -65)"
+        />
+      </svg>
+    </Button>
+  );
+};
+
+export default VercelLogo;


### PR DESCRIPTION
# Summary

- Add Vercel banner to README
- Add "Powered by ▲" to app footer

([required](https://vercel.com/support/articles/can-vercel-sponsor-my-open-source-project) by Vercel for open-source project sponsorship)

<img width="1121" alt="Screen Shot 2021-07-18 at 6 34 30 PM" src="https://user-images.githubusercontent.com/36117635/126084160-dc2cbcb3-a328-4536-82d8-304c14fc97dc.png">


TODO:
- [x]  Add a Vercel banner to the site

## Test Plan

Preview the README.md on GitHub web
Check the app on desktop, iPad, and mobile down to 375px

## Related Issues

n/a