### PR TITLE
Bugfix/175 persist auth across sessions

### DIFF
--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -47,18 +47,13 @@ function App() {
   const mapRef: any = useRef(null);
 
   /**
-   * At first render, attempt to refresh JWT from Firebase Auth
+   * Attempt to refresh the JWT from Firebase Auth
+   * Then, save or delete the JWT from local storage
    */
   useEffect(() => {
     if (!JWTtoken) {
       FirebaseAuth.currentUser?.getIdToken(true).then(setJWTtoken);
     }
-  }, []);
-
-  /**
-   * At login or logout, save or delete the JWT from local storage
-   */
-  useEffect(() => {
     localStorage.setItem("mu-auth", JSON.stringify(JWTtoken ?? null));
   }, [JWTtoken]);
 

--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -19,13 +19,20 @@ import DonationModal from "DonationModal/DonationModal";
 import WelcomeModal from "WelcomeModal/WelcomeModal";
 import VercelLogo from "components/VercelLogo";
 
+/**
+ * Check local storage for an existing JWT
+ * @returns {string | null} token or "null" parsed by JSON as null
+ */
+const loadToken = (): string | null => {
+  return JSON.parse(localStorage.getItem("mu-auth") ?? "null");
+};
+
 function App() {
   const [isSignedIn, setIsSignedIn] = useState<boolean>(false);
   const [signingIn, setSigningIn] = useState<boolean>(false);
   const [signInError, setSignInError] = useState<string>("");
   const [user, setUser] = useState<any>({});
-  const [JWTtoken, setJWTtoken] = useState<any>();
-
+  const [JWTtoken, setJWTtoken] = useState<string | null>(loadToken());
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
   const [activeForm, setActiveForm] = useState<FORM>(FORM.MURAL);
   const [formWarning, setFormWarning] = useState<boolean>(false);
@@ -40,6 +47,22 @@ function App() {
   const mapRef: any = useRef(null);
 
   /**
+   * At first render, attempt to refresh JWT from Firebase Auth
+   */
+  useEffect(() => {
+    if (!JWTtoken) {
+      FirebaseAuth.currentUser?.getIdToken(true).then(setJWTtoken);
+    }
+  }, []);
+
+  /**
+   * At login or logout, save or delete the JWT from local storage
+   */
+  useEffect(() => {
+    localStorage.setItem("mu-auth", JSON.stringify(JWTtoken ?? null));
+  }, [JWTtoken]);
+
+  /**
    * Use the Firebase Auth sign-in method email and password to
    * attempt to authorize the user. If unsuccessful, relay an error
    * message to the user.
@@ -48,10 +71,10 @@ function App() {
   const handleSignin = (creds: any) => {
     setSignInError("");
     FirebaseAuth.signInWithEmailAndPassword(creds.email, creds.password)
-      .then(() => {
+      .then(async () => {
         setSigningIn(false);
         setSignInError("");
-        setJWTtoken(FirebaseAuth.currentUser?.getIdToken(true));
+        setJWTtoken((await FirebaseAuth.currentUser?.getIdToken(true)) ?? null);
       })
       .catch((error: any) => {
         console.log(error.message);

--- a/frontend/src/CollectionForm/CollectionForm.tsx
+++ b/frontend/src/CollectionForm/CollectionForm.tsx
@@ -5,16 +5,20 @@ import {
   makeStyles,
   Snackbar,
   TextField,
-  Theme
+  Theme,
 } from "@material-ui/core";
 import axios from "axios";
 import React, { SyntheticEvent, useContext, useEffect, useState } from "react";
-import EditIcon from '@material-ui/icons/Edit';
+import EditIcon from "@material-ui/icons/Edit";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import ActionButtons from "../ActionButtons/ActionButtons";
 import SearchResultCard from "SearchResultCard/SearchResultCard";
 import Alert from "@material-ui/lab/Alert";
-import { CREATE_MURAL_API, FORM, GET_ALL_COLLECTION } from "constants/constants";
+import {
+  CREATE_MURAL_API,
+  FORM,
+  GET_ALL_COLLECTION,
+} from "constants/constants";
 import Context from "context";
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -25,11 +29,11 @@ const useStyles = makeStyles((theme: Theme) =>
       alignItems: "start",
       width: "500px",
       maxWidth: "100vw",
-      padding: theme.spacing(3)
+      padding: theme.spacing(3),
     },
     field: {
       width: "100%",
-      margin: theme.spacing(0, 0, 2, 0)
+      margin: theme.spacing(0, 0, 2, 0),
     },
     title: {
       fontSize: "180%",
@@ -44,7 +48,7 @@ interface ICollectionFormProps {
   handleMuralClick: (lat: number, long: number) => void;
   setSelectedResource: (resource: any) => void;
   setResourceType: (type: FORM) => void;
-};
+}
 
 function CollectionForm(props: ICollectionFormProps) {
   const [murals, setMurals] = useState<any>([]);
@@ -73,28 +77,32 @@ function CollectionForm(props: ICollectionFormProps) {
     if (!props.collection || !Object.keys(props.collection)) return;
     setTitle(props.collection.name);
     setDescription(props.collection.description);
-  }, [props.collection])
+  }, [props.collection]);
 
   useEffect(() => {
     if (!props.collection || murals.length === 0) return;
     let temp: any[] = [];
     props.collection.murals?.forEach((tourMural: any) => {
       let found = murals.find((mural: any) => mural.id === tourMural.id);
-      temp = ([...temp, found]);
-    })
+      temp = [...temp, found];
+    });
     setMuralsInCollection(temp);
   }, [props.collection, murals]);
 
   /**
    * Enable editable form fields for admin users
    */
-  const userContext: any = useContext(Context)
+  const userContext: any = useContext(Context);
   useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
 
   const handleAddMural = (addedMural: any) => {
-    if (!addedMural) return
-    if (muralsInCollection.some((currMural: any) => currMural.id === addedMural.id))
-      return
+    if (!addedMural) return;
+    if (
+      muralsInCollection.some(
+        (currMural: any) => currMural.id === addedMural.id
+      )
+    )
+      return;
 
     setMuralsInCollection((oldMurals: any) => [...oldMurals, addedMural]);
   };
@@ -102,18 +110,27 @@ function CollectionForm(props: ICollectionFormProps) {
   const handleSave = () => {
     if (!title.length || !description.length) return;
 
-    axios.post(GET_ALL_COLLECTION, {
-      collection: {
-        name: title,
-        description: description
-      },
-      murals: muralsInCollection.map((mural: any) => mural.id)
-    },
-    {
-      headers: {
-        authorization: userContext.token.i
-      }
-    })
+    if (!userContext.token) {
+      alert("Please log in again.");
+      return;
+    }
+
+    axios
+      .post(
+        GET_ALL_COLLECTION,
+        {
+          collection: {
+            name: title,
+            description: description,
+          },
+          murals: muralsInCollection.map((mural: any) => mural.id),
+        },
+        {
+          headers: {
+            authorization: userContext.token,
+          },
+        }
+      )
       .then(() => {
         setPopup(true);
         setTimeout(() => setPopup(false), 5000);
@@ -122,17 +139,18 @@ function CollectionForm(props: ICollectionFormProps) {
   };
 
   useEffect(() => {
-    axios.get(CREATE_MURAL_API)
+    axios
+      .get(CREATE_MURAL_API)
       .then((response) => {
-        if (response.data) setMurals(response.data.rows)
+        if (response.data) setMurals(response.data.rows);
       })
-      .catch(err => console.log(err));
+      .catch((err) => console.log(err));
   }, []);
 
   useEffect(() => {
     if (muralQuery) {
       const filtered = murals.filter((mural: any) => {
-      return mural.name.toLowerCase().includes(muralQuery)
+        return mural.name.toLowerCase().includes(muralQuery);
       });
       setMuralResults(filtered);
     } else {
@@ -145,7 +163,11 @@ function CollectionForm(props: ICollectionFormProps) {
       <form
         noValidate
         autoComplete="off"
-        onSubmit={(e: SyntheticEvent) => { e.preventDefault(); handleSave() }}>
+        onSubmit={(e: SyntheticEvent) => {
+          e.preventDefault();
+          handleSave();
+        }}
+      >
         <div className={styles.flexContainer}>
           <InputBase
             className={`${styles.title} ${styles.field}`}
@@ -153,16 +175,19 @@ function CollectionForm(props: ICollectionFormProps) {
             defaultValue={props.collection?.name}
             disabled={!isAdmin}
             onChange={(e: any) => setTitle(e.target.value)}
-            inputProps={{ 'aria-label': 'New collection title' }}
+            inputProps={{ "aria-label": "New collection title" }}
             onClick={() => setEditingTitle(true)}
             onBlur={() => setEditingTitle(false)}
             onMouseEnter={() => setHoveringTitle(true)}
             onMouseLeave={() => setHoveringTitle(false)}
-            endAdornment={!editingTitle && isAdmin && (
-              <InputAdornment position="start">
-                <EditIcon color={hoveringTitle ? "primary" : "action"} />
-              </InputAdornment>
-            )}
+            endAdornment={
+              !editingTitle &&
+              isAdmin && (
+                <InputAdornment position="start">
+                  <EditIcon color={hoveringTitle ? "primary" : "action"} />
+                </InputAdornment>
+              )
+            }
           />
           <InputBase
             className={styles.field}
@@ -176,33 +201,35 @@ function CollectionForm(props: ICollectionFormProps) {
             onBlur={() => setEditingDesc(false)}
             onMouseEnter={() => setHoveringDesc(true)}
             onMouseLeave={() => setHoveringDesc(false)}
-            endAdornment={!editingDesc && isAdmin && (
-              <InputAdornment position="start">
-                <EditIcon color={hoveringDesc ? "primary" : "action"} />
-              </InputAdornment>
-            )}
+            endAdornment={
+              !editingDesc &&
+              isAdmin && (
+                <InputAdornment position="start">
+                  <EditIcon color={hoveringDesc ? "primary" : "action"} />
+                </InputAdornment>
+              )
+            }
           />
           <div className={styles.field}>
-            {
-              isAdmin && (
-                <Autocomplete
-                  freeSolo={false}
-                  options={muralResults.map((mural: any) => mural)}
-                  getOptionLabel={(mural: any) => mural.name}
-                  onChange={(e: any, value: any) => handleAddMural(value)}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      label="Add a mural"
-                      variant="outlined"
-                      size="small"
-                      onChange={
-                        (e: any) => setMuralQuery(e.target.value.toLowerCase())
-                      }
-                    />
-                  )}
-                />)
-            }
+            {isAdmin && (
+              <Autocomplete
+                freeSolo={false}
+                options={muralResults.map((mural: any) => mural)}
+                getOptionLabel={(mural: any) => mural.name}
+                onChange={(e: any, value: any) => handleAddMural(value)}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Add a mural"
+                    variant="outlined"
+                    size="small"
+                    onChange={(e: any) =>
+                      setMuralQuery(e.target.value.toLowerCase())
+                    }
+                  />
+                )}
+              />
+            )}
           </div>
         </div>
       </form>
@@ -218,19 +245,18 @@ function CollectionForm(props: ICollectionFormProps) {
               setSelectedResource={props.setSelectedResource}
               setResourceType={props.setResourceType}
             />
-          )
+          );
         })}
       </div>
       <ActionButtons
         saveCallback={handleSave}
-        cancelCallback={props.handleCancel} />
+        cancelCallback={props.handleCancel}
+      />
       <Snackbar open={popup} autoHideDuration={6000}>
-        <Alert severity="success">
-          Collection published successfully!
-        </Alert>
+        <Alert severity="success">Collection published successfully!</Alert>
       </Snackbar>
     </div>
-  )
+  );
 }
 
 export default CollectionForm;

--- a/frontend/src/TourForm/TourForm.tsx
+++ b/frontend/src/TourForm/TourForm.tsx
@@ -74,26 +74,26 @@ function TourForm(props: ITourFormProps) {
   /**
    * Populate the form when an existing tour is passed as a prop
    */
-   useEffect(() => {
+  useEffect(() => {
     if (!props.tour || !Object.keys(props.tour)) return;
     setTitle(props.tour.name);
     setDescription(props.tour.description);
-  }, [props.tour])
+  }, [props.tour]);
 
   useEffect(() => {
     if (!props.tour || murals.length === 0) return;
     let temp: any[] = [];
     props.tour.murals?.forEach((tourMural: any) => {
       let found = murals.find((mural: any) => mural.id === tourMural.id);
-      temp = ([...temp, found]);
-    })
+      temp = [...temp, found];
+    });
     setMuralsInTour(temp);
-  }, [props.tour, murals])
+  }, [props.tour, murals]);
 
   /**
    * Enable editable form fields for admin users
    */
-  const userContext: any = useContext(Context)
+  const userContext: any = useContext(Context);
   useEffect(() => setIsAdmin(!!(userContext as any).user), [userContext]);
 
   const handleAddMural = (addedMural: any) => {
@@ -107,19 +107,28 @@ function TourForm(props: ITourFormProps) {
 
   const handleSave = () => {
     if (!title.length || !description.length) return;
-    
+
+    if (!userContext.token) {
+      alert("Please log in again.");
+      return;
+    }
+
     axios
-      .post(GET_ALL_TOUR, {
-        tour: {
-          name: title,
-          description: description,
+      .post(
+        GET_ALL_TOUR,
+        {
+          tour: {
+            name: title,
+            description: description,
+          },
+          murals: muralsInTour.map((mural: any) => mural.id),
         },
-        murals: muralsInTour.map((mural: any) => mural.id),
-      }, {
-        headers: {
-          authorization: userContext.token.i
+        {
+          headers: {
+            authorization: userContext.token,
+          },
         }
-      })
+      )
       .then(() => {
         setPopup(true);
         setTimeout(() => setPopup(false), 5000);
@@ -189,7 +198,8 @@ function TourForm(props: ITourFormProps) {
             onMouseEnter={() => setHoveringTitle(true)}
             onMouseLeave={() => setHoveringTitle(false)}
             endAdornment={
-              !editingTitle && isAdmin && (
+              !editingTitle &&
+              isAdmin && (
                 <InputAdornment position="start">
                   <EditIcon color={hoveringTitle ? "primary" : "action"} />
                 </InputAdornment>
@@ -209,7 +219,8 @@ function TourForm(props: ITourFormProps) {
             onMouseEnter={() => setHoveringDesc(true)}
             onMouseLeave={() => setHoveringDesc(false)}
             endAdornment={
-              !editingDesc && isAdmin && (
+              !editingDesc &&
+              isAdmin && (
                 <InputAdornment position="start">
                   <EditIcon color={hoveringDesc ? "primary" : "action"} />
                 </InputAdornment>
@@ -217,8 +228,7 @@ function TourForm(props: ITourFormProps) {
             }
           />
           <div className={styles.field}>
-            {
-              isAdmin &&
+            {isAdmin && (
               <Autocomplete
                 freeSolo={false}
                 options={muralResults.map((mural: any) => mural)}
@@ -236,42 +246,39 @@ function TourForm(props: ITourFormProps) {
                   />
                 )}
               />
-            }
+            )}
           </div>
-          {
-            isAdmin &&
+          {isAdmin && (
             <p className={styles.muralCount}>
               {muralsInTour.length} / 25 murals added
             </p>
-          }
+          )}
         </div>
       </form>
-      {
-        isAdmin ? (
-          <DragDrop
-            key={muralsInTour}
-            passedItems={muralsInTour}
-            itemsReorderedCallback={reorderMurals}
-            itemDeletedCallback={removeMural}
-          />
-        ) : (
-          <div className={styles.flexContainer}>
-            {muralsInTour.map((mural: any) => {
-              return (
-                <SearchResultCard
-                  type={FORM.MURAL}
-                  item={mural}
-                  key={mural.id}
-                  handleMuralClick={props.handleMuralClick}
-                  handleCancel={props.handleCancel}
-                  setSelectedResource={props.setSelectedResource}
-                  setResourceType={props.setResourceType}
-                />
-              )
-            })}
-          </div>
-        )
-      }
+      {isAdmin ? (
+        <DragDrop
+          key={muralsInTour}
+          passedItems={muralsInTour}
+          itemsReorderedCallback={reorderMurals}
+          itemDeletedCallback={removeMural}
+        />
+      ) : (
+        <div className={styles.flexContainer}>
+          {muralsInTour.map((mural: any) => {
+            return (
+              <SearchResultCard
+                type={FORM.MURAL}
+                item={mural}
+                key={mural.id}
+                handleMuralClick={props.handleMuralClick}
+                handleCancel={props.handleCancel}
+                setSelectedResource={props.setSelectedResource}
+                setResourceType={props.setResourceType}
+              />
+            );
+          })}
+        </div>
+      )}
       <ActionButtons
         saveCallback={handleSave}
         cancelCallback={props.handleCancel}

--- a/frontend/src/muralForm/MuralForm.tsx
+++ b/frontend/src/muralForm/MuralForm.tsx
@@ -166,6 +166,10 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
       alert("Please check validity of address.");
       return;
     }
+    if (!userContext.token) {
+      alert("Please log in again.");
+      return;
+    }
 
     // TODO: apply a Mural interface to this object
     let payload = {
@@ -200,7 +204,7 @@ function MuralForm({ mural, handleCancel }: IMuralFormProps) {
         : CREATE_MURAL_API,
       data: payload,
       headers: {
-        authorization: userContext.token.i,
+        authorization: userContext.token,
       },
     }).then(
       (response) => {


### PR DESCRIPTION
# Summary

- Persist login across sessions by writing the JWT to local storage
- Checks local storage for a token at first render. If none, attempt to get a fresh token from Firebase
- Applies Prettier formatting

## Test Plan

✅ Sign in, edit a mural
✅ Refresh, edit a mural again
✅ Close and reopen tab, edit a mural again
✅ Sign out, cannot edit the mural
✅ Refresh, still signed out

## Related Issues

#175 